### PR TITLE
Guess project name from the repository name

### DIFF
--- a/.zuul.yaml
+++ b/.zuul.yaml
@@ -1,6 +1,5 @@
 ---
 - project:
-    name: packit-service/dashboard
     check:
       jobs:
         - pre-commit


### PR DESCRIPTION
When zuul configuration is stored in the repository, defining 'project.name' is optional.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>