### PR TITLE
Optimize httpd memory usage

### DIFF
--- a/files/cfg/httpd_packit.conf
+++ b/files/cfg/httpd_packit.conf
@@ -1,9 +1,26 @@
+# Copyright Contributors to the Packit project.
+# SPDX-License-Identifier: MIT
 
 LogLevel info
 ErrorLog |/usr/bin/cat
 TransferLog |/usr/bin/cat
 Listen 8443
 Listen 8080
+
+# These directives are here to lower the memory usage.
+# For their description see https://httpd.apache.org/docs/2.4/mod/mpm_common.html
+# Note, Fedora's httpd is compiled with event MPM
+# https://httpd.apache.org/docs/2.4/mod/event.html
+# Number of child server PROCESSES created at startup
+StartServers 1
+# Number of THREADS created by each child server/process
+ThreadsPerChild 6
+# Minimum number of idle threads available to handle request spikes
+MinSpareThreads 2
+# Maximum number of idle threads
+MaxSpareThreads 2
+# Maximum number of connections that will be processed simultaneously (others are queued)
+MaxRequestWorkers 6
 
 <VirtualHost *:8443>
   SSLEngine on


### PR DESCRIPTION
This way it might be possible to lower the memory limit from 200MiB to
128MiB, which could save us 144MiB calculated across all projects.

Taken from packit/packit-service#596.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>