### PR TITLE
Rectify koji builds status tooltip text

### DIFF
--- a/frontend/components/koji_builds_table.js
+++ b/frontend/components/koji_builds_table.js
@@ -22,7 +22,7 @@ const StatusLabel = (props) => {
     switch (status) {
         case "success":
             return (
-                <Tooltip content={chroot}>
+                <Tooltip content="Success">
                     <span style={{ padding: "2px" }}>
                         <Label color="green">{chroot}</Label>
                     </span>
@@ -31,7 +31,7 @@ const StatusLabel = (props) => {
         // No "break;" here cause return means that the break will be unreachable
         case "failure":
             return (
-                <Tooltip content={chroot}>
+                <Tooltip content="Failure">
                     <span style={{ padding: "2px" }}>
                         <Label color="red">{chroot}</Label>
                     </span>
@@ -40,7 +40,7 @@ const StatusLabel = (props) => {
         // No "break;" here cause return means that the break will be unreachable
         default:
             return (
-                <Tooltip content={chroot}>
+                <Tooltip content="Pending">
                     <span style={{ padding: "2px" }}>
                         <Label color="purple">{chroot}</Label>
                     </span>


### PR DESCRIPTION
Earlier, the tooltip displayed the chroot which was already mentioned in the label. Meanwhile the status was only reflected by the color.
This is how it looked:
![image](https://user-images.githubusercontent.com/18102790/97614537-135ca580-1a40-11eb-9a61-3988ac638703.png)


Now the tooltip shows the status.