### PR TITLE
status: update text and say "Packit API"

### DIFF
--- a/frontend/components/status.js
+++ b/frontend/components/status.js
@@ -19,7 +19,7 @@ const Status = () => {
             .then((response) => {
                 console.log(response.status);
                 if (response.ok) {
-                    setTitle("We are healthy!");
+                    setTitle("Packit API is healthy.");
                 }
             })
             .catch((err) => {


### PR DESCRIPTION
we received feedback from @martinpitt that saying we are healthy is
confusing when builds are failing

therefore we'll instead inform that status page is about API healthiness
and not about builds