### PR TITLE
Revert "Build using Ubuntu 18.04"

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -9,9 +9,7 @@ jobs:
   build-n-push:
     # To not run in forks
     if: github.repository_owner == 'packit'
-    # https://github.com/redhat-actions/buildah-build/issues/45
-    # runs-on: ubuntu-latest
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         include:


### PR DESCRIPTION
This reverts commit 5fa6cc6884dd1ec633c13be7058c44d755c8ff40.

Should be fixed in buildah-build v2.4