### PR TITLE
Fix URL for Testing Farm if not provided

### DIFF
--- a/frontend/components/results_tf.js
+++ b/frontend/components/results_tf.js
@@ -60,6 +60,12 @@ const ResultsPageTestingFarm = (props) => {
         );
     }
 
+    const webURL = data.web_url ? (
+        <a href={data.web_url}>Web URL</a>
+    ) : (
+        "URL has not been provided"
+    );
+
     return (
         <div>
             <PageSection variant={PageSectionVariants.light}>
@@ -94,9 +100,7 @@ const ResultsPageTestingFarm = (props) => {
                                     <td>
                                         <strong>Testing Farm URL</strong>
                                     </td>
-                                    <td>
-                                        <a href={data.web_url}>Web URL</a>
-                                    </td>
+                                    <td>{webURL}</td>
                                 </tr>
                                 <tr>
                                     <td>


### PR DESCRIPTION
In case the state of testing farm run is `new`, the URL is not
provided and we displayed clickable link with no URL.

Fixes #94

Signed-off-by: Matej Focko <mfocko@redhat.com>