### PR TITLE
Fix buildah image build

### DIFF
--- a/files/ansible/recipe.yaml
+++ b/files/ansible/recipe.yaml
@@ -8,6 +8,11 @@
     - import_tasks: common.yaml
     - import_tasks: httpd.yaml
 
+    - name: install node modules
+      command:
+        chdir: "{{ packit_dashboard_path }}"
+        cmd: npm install
+
     - name: bundle javascript
       command:
         chdir: "{{ packit_dashboard_path }}"


### PR DESCRIPTION
Forgot to add the install node modules task in ansible. A step in the Containerfile copies the entire frontend folder so I didnt encounter this locally as it copied my node_modules.

Fixes https://github.com/packit/dashboard/actions/runs/842199459

~~(I'm checking image build on a clean git clone now, wait afew minutes)~~ Checked. It's working fine