### PR TITLE
Fix shrinking of Copr/Koji icons

### DIFF
--- a/frontend/src/components/tables/pipelines.js
+++ b/frontend/src/components/tables/pipelines.js
@@ -42,7 +42,12 @@ class Statuses extends React.Component {
 }
 
 function getBuilderLabel(run) {
-    const iconStyle = { width: "14px", height: "14px" };
+    const iconStyle = {
+        minWidth: "14px",
+        minHeight: "14px",
+        width: "14px",
+        height: "14px",
+    };
 
     let text = "none";
     let icon = undefined;


### PR DESCRIPTION
Fixes #139

---

<!-- release notes for changelog/blog follow -->

Dashboard no longer shrinks Copr/Koji icons when being open in narrow view.