### PR TITLE
Datetime improvements

### DIFF
--- a/frontend/src/components/results/copr.js
+++ b/frontend/src/components/results/copr.js
@@ -13,6 +13,7 @@ import ConnectionError from "../error";
 import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { StatusLabel } from "../status_labels";
+import { Timestamp } from "../../utils/time";
 
 const ResultsPageCopr = (props) => {
     let id = props.match.params.id;
@@ -161,19 +162,34 @@ const ResultsPageCopr = (props) => {
                                     <td>
                                         <strong>Build Submission Time</strong>
                                     </td>
-                                    <td>{data.build_submitted_time}</td>
+                                    <td>
+                                        <Timestamp
+                                            stamp={data.build_submitted_time}
+                                            verbose={true}
+                                        />
+                                    </td>
                                 </tr>
                                 <tr>
                                     <td>
                                         <strong>Build Start Time</strong>
                                     </td>
-                                    <td>{data.build_start_time}</td>
+                                    <td>
+                                        <Timestamp
+                                            stamp={data.build_start_time}
+                                            verbose={true}
+                                        />
+                                    </td>
                                 </tr>
                                 <tr>
                                     <td>
                                         <strong>Build Finish Time</strong>
                                     </td>
-                                    <td>{data.build_finished_time}</td>
+                                    <td>
+                                        <Timestamp
+                                            stamp={data.build_finished_time}
+                                            verbose={true}
+                                        />
+                                    </td>
                                 </tr>
                                 <tr>
                                     <td>

--- a/frontend/src/components/results/koji.js
+++ b/frontend/src/components/results/koji.js
@@ -13,6 +13,7 @@ import ConnectionError from "../error";
 import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { StatusLabel } from "../status_labels";
+import { Timestamp } from "../../utils/time";
 
 const ResultsPageKoji = (props) => {
     let id = props.match.params.id;
@@ -123,19 +124,34 @@ const ResultsPageKoji = (props) => {
                                     <td>
                                         <strong>Build Submission Time</strong>
                                     </td>
-                                    <td>{data.build_submitted_time}</td>
+                                    <td>
+                                        <Timestamp
+                                            stamp={data.build_submitted_time}
+                                            verbose={true}
+                                        />
+                                    </td>
                                 </tr>
                                 <tr>
                                     <td>
                                         <strong>Build Start Time</strong>
                                     </td>
-                                    <td>{data.build_start_time}</td>
+                                    <td>
+                                        <Timestamp
+                                            stamp={data.build_start_time}
+                                            verbose={true}
+                                        />
+                                    </td>
                                 </tr>
                                 <tr>
                                     <td>
                                         <strong>Build Finish Time</strong>
                                     </td>
-                                    <td>{data.build_finished_time}</td>
+                                    <td>
+                                        <Timestamp
+                                            stamp={data.build_finished_time}
+                                            verbose={true}
+                                        />
+                                    </td>
                                 </tr>
                                 <tr>
                                     <td>

--- a/frontend/src/components/results/srpm.js
+++ b/frontend/src/components/results/srpm.js
@@ -17,6 +17,7 @@ import ConnectionError from "../error";
 import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { StatusLabel, toSRPMStatus } from "../status_labels";
+import { Timestamp } from "../../utils/time";
 
 const ResultsPageSRPM = (props) => {
     let id = props.match.params.id;
@@ -81,7 +82,11 @@ const ResultsPageSRPM = (props) => {
                             <TriggerLink builds={data} />
                         </strong>
                         <br />
-                        Submitted at {data.build_submitted_time}
+                        Submitted at{" "}
+                        <Timestamp
+                            stamp={data.build_submitted_time}
+                            verbose={true}
+                        />
                     </Text>
                     <Text component="p">SRPM: {srpmURL}</Text>
                 </TextContent>

--- a/frontend/src/components/results/testing_farm.js
+++ b/frontend/src/components/results/testing_farm.js
@@ -14,6 +14,7 @@ import ConnectionError from "../error";
 import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { TFStatusLabel } from "../status_labels";
+import { Timestamp } from "../../utils/time";
 
 const ResultsPageTestingFarm = (props) => {
     let id = props.match.params.id;

--- a/frontend/src/components/tables/copr.js
+++ b/frontend/src/components/tables/copr.js
@@ -16,6 +16,7 @@ import ConnectionError from "../error";
 import Preloader from "../preloader";
 import ForgeIcon from "../forge_icon";
 import { StatusLabel } from "../status_labels";
+import { Timestamp } from "../../utils/time";
 
 // Add every target to the chroots column and color code according to status
 const ChrootStatuses = (props) => {
@@ -97,7 +98,13 @@ const CoprBuildsTable = () => {
                             />
                         ),
                     },
-                    copr_builds.build_submitted_time,
+                    {
+                        title: (
+                            <Timestamp
+                                stamp={copr_builds.build_submitted_time}
+                            />
+                        ),
+                    },
                     {
                         title: (
                             <strong>

--- a/frontend/src/components/tables/koji.js
+++ b/frontend/src/components/tables/koji.js
@@ -16,6 +16,7 @@ import ConnectionError from "../error";
 import Preloader from "../preloader";
 import ForgeIcon from "../forge_icon";
 import { StatusLabel } from "../status_labels";
+import { Timestamp } from "../../utils/time";
 
 const KojiBuildsTable = () => {
     // Headings
@@ -78,7 +79,13 @@ const KojiBuildsTable = () => {
                             />
                         ),
                     },
-                    koji_builds.build_submitted_time,
+                    {
+                        title: (
+                            <Timestamp
+                                stamp={koji_builds.build_submitted_time}
+                            />
+                        ),
+                    },
                     {
                         title: (
                             <strong>

--- a/frontend/src/components/tables/pipelines.js
+++ b/frontend/src/components/tables/pipelines.js
@@ -16,6 +16,7 @@ import ConnectionError from "../error";
 import Preloader from "../preloader";
 import ForgeIcon from "../forge_icon";
 import { StatusLabel, toSRPMStatus, TFStatusLabel } from "../status_labels";
+import { Timestamp } from "../../utils/time";
 import coprLogo from "../../static/copr.ico";
 import kojiLogo from "../../static/koji.ico";
 
@@ -119,7 +120,7 @@ const PipelinesTable = () => {
                             </strong>
                         ),
                     },
-                    run.time_submitted,
+                    { title: <Timestamp stamp={run.time_submitted} /> },
                     {
                         title: (
                             <StatusLabel

--- a/frontend/src/components/tables/srpm.js
+++ b/frontend/src/components/tables/srpm.js
@@ -17,6 +17,7 @@ import TriggerLink from "../trigger_link";
 import Preloader from "../preloader";
 import ForgeIcon from "../forge_icon";
 import { StatusLabel, toSRPMStatus } from "../status_labels";
+import { Timestamp } from "../../utils/time";
 
 const SRPMBuildstable = () => {
     // Headings
@@ -79,7 +80,11 @@ const SRPMBuildstable = () => {
                         ),
                     },
                     {
-                        title: <span>{srpm_builds.build_submitted_time}</span>,
+                        title: (
+                            <Timestamp
+                                stamp={srpm_builds.build_submitted_time}
+                            />
+                        ),
                     },
                     {
                         title: (

--- a/frontend/src/components/tables/testing_farm.js
+++ b/frontend/src/components/tables/testing_farm.js
@@ -17,6 +17,7 @@ import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import ForgeIcon from "../forge_icon";
 import { TFStatusLabel } from "../status_labels";
+import { Timestamp } from "../../utils/time";
 
 const TestingFarmResultsTable = () => {
     const column_list = [
@@ -85,7 +86,9 @@ const TestingFarmResultsTable = () => {
                         ),
                     },
                     {
-                        title: test_results.submitted_time || "not provided",
+                        title: (
+                            <Timestamp stamp={test_results.submitted_time} />
+                        ),
                     },
                     {
                         title: (

--- a/frontend/src/utils/time.js
+++ b/frontend/src/utils/time.js
@@ -1,0 +1,48 @@
+/*
+ * Get a pretty string like 'an hour ago', 'yesterday', '3 months ago',
+ * 'just now'.
+ * https://stackoverflow.com/questions/1551382/user-friendly-time-format-in-python
+ */
+const prettyTime = (time) => {
+    if (time === null) {
+        return null;
+    }
+
+    // Convert UNIX timestamp into date object, Date gets passed **milliseconds**
+    // since Epoch.
+    time = new Date(1000 * time);
+
+    let now = Date.now();
+    let diff = Math.floor((now - time) / 1000);
+
+    let secondDiff = diff % 60;
+    let dayDiff = Math.floor(diff / (60 * 60 * 24));
+
+    if (dayDiff == 0) {
+        if (secondDiff < 10) {
+            return "just now";
+        } else if (secondDiff < 60) {
+            return secondDiff + " seconds ago";
+        } else if (secondDiff < 120) {
+            return "a minute ago";
+        } else if (secondDiff < 3600) {
+            return secondDiff / 60 + " minutes ago";
+        } else if (secondDiff < 7200) {
+            return "an hour ago";
+        }
+        return secondDiff / 3600 + " hours ago";
+    }
+
+    if (dayDiff == 1) {
+        return "yesterday";
+    } else if (dayDiff < 7) {
+        return dayDiff + " days ago";
+    } else if (dayDiff < 31) {
+        return dayDiff / 7 + " weeks ago";
+    } else if (dayDiff < 365) {
+        return dayDiff / 30 + " months ago";
+    }
+    return dayDiff / 365 + " years ago";
+};
+
+export { prettyTime };

--- a/frontend/src/utils/time.js
+++ b/frontend/src/utils/time.js
@@ -1,48 +1,76 @@
+import { Text, Tooltip } from "@patternfly/react-core";
+
 /*
  * Get a pretty string like 'an hour ago', 'yesterday', '3 months ago',
  * 'just now'.
  * https://stackoverflow.com/questions/1551382/user-friendly-time-format-in-python
  */
-const prettyTime = (time) => {
-    if (time === null) {
+const prettyTimeDifference = (difference) => {
+    let secondDiff = difference;
+    let dayDiff = Math.floor(difference / (60 * 60 * 24));
+
+    let numericPart = dayDiff / 365;
+    let units = " years ago";
+
+    if (dayDiff == 0) {
+        [numericPart, units] = [secondDiff / 3600, " hours ago"];
+
+        if (secondDiff < 10) {
+            [numericPart, units] = [null, "just now"];
+        } else if (secondDiff < 60) {
+            [numericPart, units] = [secondDiff, " seconds ago"];
+        } else if (secondDiff < 120) {
+            [numericPart, units] = [null, "a minute ago"];
+        } else if (secondDiff < 3600) {
+            [numericPart, units] = [secondDiff / 60, " minutes ago"];
+        } else if (secondDiff < 7200) {
+            [numericPart, units] = [null, "an hour ago"];
+        }
+    } else if (dayDiff == 1) {
+        [numericPart, units] = [null, "yesterday"];
+    } else if (dayDiff < 7) {
+        [numericPart, units] = [dayDiff, " days ago"];
+    } else if (dayDiff < 31) {
+        [numericPart, units] = [dayDiff / 7, " weeks ago"];
+    } else if (dayDiff < 365) {
+        [numericPart, units] = [dayDiff / 30, " months ago"];
+    }
+
+    return `${Math.floor(numericPart) || ""}${units}`;
+};
+
+const getPrettyTime = (date) => {
+    if (date === null) {
         return null;
+    }
+
+    let now = Date.now();
+    let diff = Math.floor((now - date) / 1000);
+
+    return prettyTimeDifference(diff);
+};
+
+const Timestamp = (props) => {
+    if (props.stamp === null) {
+        return <span>not provided</span>;
     }
 
     // Convert UNIX timestamp into date object, Date gets passed **milliseconds**
     // since Epoch.
-    time = new Date(1000 * time);
+    const time = new Date(1000 * props.stamp);
 
-    let now = Date.now();
-    let diff = Math.floor((now - time) / 1000);
+    let prettyTime = getPrettyTime(time);
+    let verboseTime = time.toLocaleString();
 
-    let secondDiff = diff % 60;
-    let dayDiff = Math.floor(diff / (60 * 60 * 24));
-
-    if (dayDiff == 0) {
-        if (secondDiff < 10) {
-            return "just now";
-        } else if (secondDiff < 60) {
-            return secondDiff + " seconds ago";
-        } else if (secondDiff < 120) {
-            return "a minute ago";
-        } else if (secondDiff < 3600) {
-            return secondDiff / 60 + " minutes ago";
-        } else if (secondDiff < 7200) {
-            return "an hour ago";
-        }
-        return secondDiff / 3600 + " hours ago";
+    if (props.verbose) {
+        [prettyTime, verboseTime] = [verboseTime, prettyTime];
     }
 
-    if (dayDiff == 1) {
-        return "yesterday";
-    } else if (dayDiff < 7) {
-        return dayDiff + " days ago";
-    } else if (dayDiff < 31) {
-        return dayDiff / 7 + " weeks ago";
-    } else if (dayDiff < 365) {
-        return dayDiff / 30 + " months ago";
-    }
-    return dayDiff / 365 + " years ago";
+    return (
+        <Tooltip content={verboseTime}>
+            <span>{prettyTime}</span>
+        </Tooltip>
+    );
 };
 
-export { prettyTime };
+export { Timestamp };


### PR DESCRIPTION
<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Merge with packit/packit-service#1223

---

<!-- release notes for changelog/blog follow -->

Dashboard now shows more readable format of time, e.g. _just now_, _a minute ago_, etc. If you wish to see exact date-time of the run, you can either hover over the time and tooltip with details appear. In case of result pages more readable format is present in the tooltip rather than by default. Also times are now shown in your local time zone.

For tables: ![](https://i.imgur.com/pP0qh6c.png)
For results: ![](https://i.imgur.com/ibQx27p.png)