### PR TITLE
Do not open new tab from logo

### DIFF
--- a/frontend/src/components/app_layout.js
+++ b/frontend/src/components/app_layout.js
@@ -16,7 +16,6 @@ import packitLogo from "../static/logo.png";
 const AppLayout = ({ children }) => {
     const logoProps = {
         href: "/",
-        target: "_blank",
     };
     const [isNavOpen, setIsNavOpen] = React.useState(true);
     const [isMobileView, setIsMobileView] = React.useState(true);


### PR DESCRIPTION
Fixes #126

---

<!-- release notes for changelog/blog follow -->

Clicking on logo on dashboard no longer opens a new page, but rather reloads the current one.