### PR TITLE
Don't try to display copr build for tf without build phase

### DIFF
--- a/frontend/src/components/results/testing_farm.js
+++ b/frontend/src/components/results/testing_farm.js
@@ -68,6 +68,21 @@ const ResultsPageTestingFarm = (props) => {
         <>{data.status}</>
     );
 
+    const coprBuildInfo = data.copr_build_id ? (
+        <tr>
+            <td>
+                <strong>COPR build</strong>
+            </td>
+            <td>
+                <a href={`/results/copr-builds/${data.copr_build_id}`}>
+                    Details
+                </a>
+            </td>
+        </tr>
+    ) : (
+        ""
+    );
+
     return (
         <div>
             <PageSection variant={PageSectionVariants.light}>
@@ -102,18 +117,7 @@ const ResultsPageTestingFarm = (props) => {
                                     </td>
                                     <td>{statusWithLink}</td>
                                 </tr>
-                                <tr>
-                                    <td>
-                                        <strong>COPR build</strong>
-                                    </td>
-                                    <td>
-                                        <a
-                                            href={`/results/copr-builds/${data.copr_build_id}`}
-                                        >
-                                            Details
-                                        </a>
-                                    </td>
-                                </tr>
+                                {coprBuildInfo}
                                 <tr>
                                     <td>
                                         <strong>Pipeline ID</strong>


### PR DESCRIPTION


Related to packit/packit-service#1256

Result for tests without build phase:
![Snímka obrazovky z 2021-11-10 14-17-15](https://user-images.githubusercontent.com/49026743/141120517-e2ea9502-bca7-43a1-93b0-eea89ddd4c03.png)


