### PR TITLE
Update pipelines view for tests without build

### DIFF
--- a/frontend/src/components/tables/pipelines.js
+++ b/frontend/src/components/tables/pipelines.js
@@ -108,6 +108,16 @@ const PipelinesTable = () => {
         let rowsList = [];
 
         res.map((run) => {
+            let srpm = run.srpm ? (
+                <StatusLabel
+                    status={toSRPMStatus(run.srpm.success)}
+                    link={`/results/srpm-builds/${run.srpm.packit_id}`}
+                />
+            ) : (
+                <Label variant={"outline"} icon={undefined}>
+                    {"none"}
+                </Label>
+            );
             let singleRow = {
                 cells: [
                     {
@@ -121,14 +131,7 @@ const PipelinesTable = () => {
                         ),
                     },
                     { title: <Timestamp stamp={run.time_submitted} /> },
-                    {
-                        title: (
-                            <StatusLabel
-                                status={toSRPMStatus(run.srpm.success)}
-                                link={`/results/srpm-builds/${run.srpm.packit_id}`}
-                            />
-                        ),
-                    },
+                    { title: srpm },
                     {
                         title: getBuilderLabel(run),
                     },


### PR DESCRIPTION
Merge after packit/packit-service#1282 to check whether it displays it correctly with that change (it should split current one pipeline into separate).
![Snímka obrazovky z 2021-11-12 00-25-24](https://user-images.githubusercontent.com/49026743/141383378-c2f6f832-264b-4e97-b34b-138e3f106607.png)


