### PR TITLE
SRPM Build result page: display info when log is missing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ build-stg:
 push-stg: build-stg
 	$(CONTAINER_ENGINE) push $(IMAGE)
 
-oc-push-stg:
+oc-import-image:
 	oc import-image is/packit-dashboard:stg
 
 check:

--- a/frontend/src/components/results/srpm.js
+++ b/frontend/src/components/results/srpm.js
@@ -96,7 +96,9 @@ const ResultsPageSRPM = (props) => {
                 <Card>
                     <CardBody>
                         <LogViewer
-                            data={data.logs}
+                            data={
+                                data.logs ? data.logs : "Log is not available"
+                            }
                             toolbar={
                                 <Toolbar>
                                     <ToolbarContent>


### PR DESCRIPTION
![Screenshot from 2021-12-21 14-02-21](https://user-images.githubusercontent.com/288686/146934686-6a51dbbd-af44-4142-9b72-92b345d2aa28.jpg)

Merge before: packit/packit-service#1315

---

N/A
