### PR TITLE
Update views to reflect SRPM changes related to building in Copr

### DIFF
--- a/frontend/src/components/results/srpm.js
+++ b/frontend/src/components/results/srpm.js
@@ -105,7 +105,6 @@ const ResultsPageSRPM = (props) => {
         ""
     );
 
-
     const logs = data.copr_build_id ? (
         ""
     ) : (

--- a/frontend/src/components/results/srpm.js
+++ b/frontend/src/components/results/srpm.js
@@ -71,47 +71,88 @@ const ResultsPageSRPM = (props) => {
         "Not available to download"
     );
 
+    const submittedAt = data.build_submitted_time ? (
+        <Timestamp stamp={data.build_submitted_time} verbose={true} />
+    ) : (
+        "not available"
+    );
+
+    const startedAt = data.build_start_time ? (
+        <Timestamp stamp={data.build_start_time} verbose={true} />
+    ) : (
+        "not available"
+    );
+
+    const finishedAt = data.build_finished_time ? (
+        <Timestamp stamp={data.build_finished_time} verbose={true} />
+    ) : (
+        "not available"
+    );
+
+    const coprLogsUrl = data.logs_url ? (
+        <a href={data.logs_url}>Logs URL</a>
+    ) : (
+        "not available"
+    );
+
+    const coprInfo = data.copr_build_id ? (
+        <Text component="p">
+            Copr Web URL: <a href={data.copr_web_url}>URL</a>
+            <br />
+            Copr SRPM build logs: {coprLogsUrl}
+        </Text>
+    ) : (
+        ""
+    );
+
+
+    const logs = data.copr_build_id ? (
+        ""
+    ) : (
+        <PageSection>
+            <Card>
+                <CardBody>
+                    <LogViewer
+                        data={data.logs ? data.logs : "Log is not available"}
+                        toolbar={
+                            <Toolbar>
+                                <ToolbarContent>
+                                    <ToolbarItem>
+                                        <LogViewerSearch placeholder="Search value" />
+                                    </ToolbarItem>
+                                </ToolbarContent>
+                            </Toolbar>
+                        }
+                    />
+                </CardBody>
+            </Card>
+        </PageSection>
+    );
+
     return (
         <div>
             <PageSection variant={PageSectionVariants.light}>
                 <TextContent>
                     <Text component="h1">SRPM Build</Text>
-                    <StatusLabel status={toSRPMStatus(data.success)} />
+                    <StatusLabel status={data.status} />
                     <Text component="p">
                         <strong>
                             <TriggerLink builds={data} />
                         </strong>
                         <br />
-                        Submitted at{" "}
-                        <Timestamp
-                            stamp={data.build_submitted_time}
-                            verbose={true}
-                        />
+                        Submitted at: {submittedAt}
+                        <br />
+                        Started at: {startedAt}
+                        <br />
+                        Finished at: {finishedAt}
+                        <br />
                     </Text>
+                    {coprInfo}
                     <Text component="p">SRPM: {srpmURL}</Text>
                 </TextContent>
             </PageSection>
 
-            <PageSection>
-                <Card>
-                    <CardBody>
-                        <LogViewer
-                            data={
-                                data.logs ? data.logs : "Log is not available"
-                            }
-                            toolbar={
-                                <Toolbar>
-                                    <ToolbarContent>
-                                        <ToolbarItem>
-                                            <LogViewerSearch placeholder="Search value" />
-                                        </ToolbarItem>
-                                    </ToolbarContent>
-                                </Toolbar>
-                            }
-                        />
-                    </CardBody>
-                </Card>
-            </PageSection>
+            {logs}
         </div>
     );
 };

--- a/frontend/src/components/tables/pipelines.js
+++ b/frontend/src/components/tables/pipelines.js
@@ -110,7 +110,7 @@ const PipelinesTable = () => {
         res.map((run) => {
             let srpm = run.srpm ? (
                 <StatusLabel
-                    status={toSRPMStatus(run.srpm.success)}
+                    status={run.srpm.status}
                     link={`/results/srpm-builds/${run.srpm.packit_id}`}
                 />
             ) : (

--- a/frontend/src/components/tables/srpm.js
+++ b/frontend/src/components/tables/srpm.js
@@ -73,7 +73,7 @@ const SRPMBuildstable = () => {
                     {
                         title: (
                             <StatusLabel
-                                status={toSRPMStatus(srpm_builds.success)}
+                                status={srpm_builds.status}
                                 link={`/results/srpm-builds/${srpm_builds.srpm_build_id}`}
                             />
                         ),

--- a/frontend/src/components/trigger_info.js
+++ b/frontend/src/components/trigger_info.js
@@ -98,8 +98,8 @@ const TriggerInfo = (props) => {
                                 <td role="cell" data-label="SRPM Build ID">
                                     {build.srpm_build_id}
                                 </td>
-                                <td role="cell" data-label="Success">
-                                    {String(build.success)}
+                                <td role="cell" data-label="Status">
+                                    {build.status}
                                 </td>
                                 <td role="cell" data-label="Logs">
                                     <WebUrlIcon link={build.log_url} />


### PR DESCRIPTION
SRPMBuildModel in packit-service was updated, it has now status attribute instead
of success and additional Copr related attributes, these changes are reflected into
packit-service API and the info we process in dashboard, therefore the views
need to be updated to show correct status and new info.


Related to packit/packit-service#1324

For SRPMs built by us we will show also start and finished time:
![Snímka obrazovky z 2022-01-25 12-49-50](https://user-images.githubusercontent.com/49026743/150972860-f73b3057-095e-4f1e-a4e2-a4e1a5be0d9f.png)

For SRPMs built in Copr there are additional links:
![Snímka obrazovky z 2022-01-25 12-47-53](https://user-images.githubusercontent.com/49026743/150972944-d9840a44-a975-4c39-bb2e-6ae766eabf85.png)

---

<!-- release notes for changelog/blog follow -->
