### PR TITLE
fix(srpm): disable line numbers in logs

### DIFF
--- a/frontend/src/components/results/srpm.js
+++ b/frontend/src/components/results/srpm.js
@@ -122,6 +122,7 @@ const ResultsPageSRPM = (props) => {
                                 </ToolbarContent>
                             </Toolbar>
                         }
+                        hasLineNumbers={false}
                     />
                 </CardBody>
             </Card>


### PR DESCRIPTION
Since there is an issue with wrapping and overlap of line numbers with
actual logs, disable the line numbers till it's fixed on the side of
patternfly's log viewer.

Fixes #166

Signed-off-by: Matej Focko <mfocko@redhat.com>

<!-- notes for reviewers -->

- since we have low traffic on the dashboard repo, let's try conventional commits here
  - will create some pre-commit check for it in separate commit

RELEASE NOTES BEGIN
Issue with displaying of SRPM logs on dashboard has been fixed by disabling the line numbers until it's fixed on the side of the React framework we are using.
RELEASE NOTES END