### PR TITLE
View for propose-downstream

### DIFF
--- a/frontend/src/components/jobs.js
+++ b/frontend/src/components/jobs.js
@@ -14,6 +14,7 @@ import TestingFarmResultsTable from "./tables/testing_farm";
 import CoprBuildsTable from "./tables/copr";
 import KojiBuildsTable from "./tables/koji";
 import SRPMBuildsTable from "./tables/srpm";
+import ProposeDownstreamTable from "./tables/propose_downstream";
 
 const Jobs = () => {
     const [activeTabKey, setActiveTabKey] = React.useState(0);
@@ -61,6 +62,16 @@ const Jobs = () => {
                                 title={<TabTitleText>Test Runs</TabTitleText>}
                             >
                                 <TestingFarmResultsTable />
+                            </Tab>
+                            <Tab
+                                eventKey={4}
+                                title={
+                                    <TabTitleText>
+                                        Propose Downstreams
+                                    </TabTitleText>
+                                }
+                            >
+                                <ProposeDownstreamTable />
                             </Tab>
                         </Tabs>
                     </CardBody>

--- a/frontend/src/components/results/propose_downstream.js
+++ b/frontend/src/components/results/propose_downstream.js
@@ -1,0 +1,179 @@
+import React, { useState, useEffect } from "react";
+import {
+    PageSection,
+    Card,
+    CardBody,
+    PageSectionVariants,
+    TextContent,
+    Text,
+    Title,
+    Toolbar,
+    ToolbarContent,
+    ToolbarItem,
+} from "@patternfly/react-core";
+
+import ConnectionError from "../error";
+import Preloader from "../preloader";
+import TriggerLink from "../trigger_link";
+import { ProposeDownstreamTargetStatusLabel } from "../status_labels";
+import { Timestamp } from "../../utils/time";
+import { LogViewer, LogViewerSearch } from "@patternfly/react-log-viewer";
+
+const ResultsPageProposeDownstream = (props) => {
+    let id = props.match.params.id;
+
+    const [hasError, setErrors] = useState(false);
+    const [loaded, setLoaded] = useState(false);
+    const [data, setData] = useState({});
+
+    useEffect(() => {
+        fetch(`${process.env.REACT_APP_API_URL}/propose-downstream/${id}`)
+            .then((response) => response.json())
+            .then((data) => {
+                setData(data);
+                setLoaded(true);
+            })
+            .catch((err) => {
+                console.log(err);
+                setErrors(err);
+            });
+    }, []);
+
+    // If backend API is down
+    if (hasError) {
+        return <ConnectionError />;
+    }
+
+    // Show preloader if waiting for API data
+    if (!loaded) {
+        return <Preloader />;
+    }
+
+    if ("error" in data) {
+        return (
+            <PageSection>
+                <Card>
+                    <CardBody>
+                        <Title headingLevel="h1" size="lg">
+                            Not Found.
+                        </Title>
+                    </CardBody>
+                </Card>
+            </PageSection>
+        );
+    }
+
+    const linkToDownstreamPR = data.downstream_pr_url ? (
+        <a href={data.downstream_pr_url}>Click here</a>
+    ) : (
+        <>Link will be available after successful downstream PR submission.</>
+    );
+
+    const logs = (
+        <PageSection>
+            <Card>
+                <CardBody>
+                    <LogViewer
+                        data={
+                            data.logs ? data.logs : "Log is not available yet."
+                        }
+                        toolbar={
+                            <Toolbar>
+                                <ToolbarContent>
+                                    <ToolbarItem>
+                                        <LogViewerSearch placeholder="Search value" />
+                                    </ToolbarItem>
+                                </ToolbarContent>
+                            </Toolbar>
+                        }
+                        hasLineNumbers={false}
+                    />
+                </CardBody>
+            </Card>
+        </PageSection>
+    );
+
+    return (
+        <div>
+            <PageSection variant={PageSectionVariants.light}>
+                <TextContent>
+                    <Text component="h1">Propose Downstream Results</Text>
+                    <ProposeDownstreamTargetStatusLabel
+                        status={data.status}
+                        target={data.branch}
+                        link={data.downstream_pr_url}
+                    />
+                    <Text component="p">
+                        <strong>
+                            <TriggerLink builds={data} />
+                        </strong>
+                        <br />
+                    </Text>
+                </TextContent>
+            </PageSection>
+
+            <PageSection>
+                <Card>
+                    <CardBody>
+                        <table
+                            className="pf-c-table pf-m-compact pf-m-grid-md"
+                            role="grid"
+                            aria-label="Propose table"
+                        >
+                            <tbody role="rowgroup">
+                                <tr>
+                                    <td>
+                                        <strong>Status</strong>
+                                    </td>
+                                    <td>{data.status}</td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <strong>Submission Time</strong>
+                                    </td>
+                                    <td>
+                                        <Timestamp
+                                            stamp={data.submitted_time}
+                                            verbose={true}
+                                        />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <strong>Start Time</strong>
+                                    </td>
+                                    <td>
+                                        <Timestamp
+                                            stamp={data.start_time}
+                                            verbose={true}
+                                        />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <strong>Finish Time</strong>
+                                    </td>
+                                    <td>
+                                        <Timestamp
+                                            stamp={data.finished_time}
+                                            verbose={true}
+                                        />
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <strong>Link to downstream PR</strong>
+                                    </td>
+                                    <td>{linkToDownstreamPR}</td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </CardBody>
+                </Card>
+            </PageSection>
+            {logs}
+        </div>
+    );
+};
+
+export { ResultsPageProposeDownstream };

--- a/frontend/src/components/status_labels.js
+++ b/frontend/src/components/status_labels.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Label, Tooltip } from "@patternfly/react-core";
+import { Label, Tooltip, Spinner } from "@patternfly/react-core";
 
 import PropTypes from "prop-types";
 import {
@@ -7,6 +7,7 @@ import {
     ExclamationCircleIcon,
     ExclamationTriangleIcon,
     InfoCircleIcon,
+    RedoIcon,
 } from "@patternfly/react-icons";
 
 /**
@@ -125,6 +126,52 @@ class TFStatusLabel extends BaseStatusLabel {
 }
 
 /**
+ *  Status label that handles ProposeDownstreamTarget labels, since they have different
+ *  naming convention and meaning for each ProposeDownstreamTarget.
+ */
+class ProposeDownstreamTargetStatusLabel extends BaseStatusLabel {
+    static propTypes = {
+        link: PropTypes.string,
+        status: PropTypes.string,
+        target: PropTypes.string,
+    };
+
+    /**
+     * Creates ProposeDownstreamTarget status label. Label is set to target.
+     *
+     * @param {*} props Properties of the status label, minimal requirements are:
+     *  status and target.
+     */
+    constructor(props) {
+        super(props);
+
+        this.label = props.target;
+        switch (props.status) {
+            case "running":
+                this.color = "blue";
+                this.icon = <Spinner isSVG diameter="15px" />;
+                break;
+            case "error":
+                this.color = "red";
+                this.icon = <ExclamationCircleIcon />;
+                break;
+            case "retry":
+                this.color = "orange";
+                this.icon = <RedoIcon />;
+                break;
+            case "submitted":
+                this.color = "green";
+                this.icon = <CheckCircleIcon />;
+                break;
+            default:
+                this.color = "purple";
+                this.icon = <InfoCircleIcon />;
+                break;
+        }
+    }
+}
+
+/**
  * Provides basic mapping of `boolean` result of SRPM build to the `string`
  * representation that can be used by classes above.
  *
@@ -135,4 +182,9 @@ function toSRPMStatus(success) {
     return success ? "success" : "failure";
 }
 
-export { StatusLabel, TFStatusLabel, toSRPMStatus };
+export {
+    StatusLabel,
+    TFStatusLabel,
+    ProposeDownstreamTargetStatusLabel,
+    toSRPMStatus,
+};

--- a/frontend/src/components/tables/propose_downstream.js
+++ b/frontend/src/components/tables/propose_downstream.js
@@ -1,0 +1,178 @@
+import React, { useState, useEffect } from "react";
+
+import {
+    Table,
+    TableHeader,
+    TableBody,
+    TableVariant,
+    sortable,
+    SortByDirection,
+    cellWidth,
+} from "@patternfly/react-table";
+
+import { Button } from "@patternfly/react-core";
+import TriggerLink from "../trigger_link";
+import ConnectionError from "../error";
+import Preloader from "../preloader";
+import ForgeIcon from "../forge_icon";
+import { ProposeDownstreamTargetStatusLabel } from "../status_labels";
+import { Timestamp } from "../../utils/time";
+
+const ProposeDownstreamStatuses = (props) => {
+    let labels = [];
+
+    for (let target in props.ids) {
+        const id = props.ids[target];
+        const status = props.statuses[target];
+
+        labels.push(
+            <ProposeDownstreamTargetStatusLabel
+                link={`/results/propose-downstream/${id}`}
+                status={status}
+                target={target}
+            />
+        );
+    }
+
+    return <div>{labels}</div>;
+};
+
+const ProposeDownstreamsTable = () => {
+    // Headings
+    const column_list = [
+        { title: "", transforms: [cellWidth(5)] }, // space for forge icon
+        { title: "Trigger", transforms: [cellWidth(25)] },
+        { title: "Targets", transforms: [cellWidth(60)] },
+        { title: "Time Submitted", transforms: [sortable, cellWidth(20)] },
+    ];
+
+    // Local State
+    const [columns, setColumns] = useState(column_list);
+    const [rows, setRows] = useState([]);
+    const [hasError, setErrors] = useState(false);
+    const [loaded, setLoaded] = useState(false);
+    const [sortBy, setSortBy] = useState({});
+    const [page, setPage] = useState(1);
+
+    // Fetch data from dashboard backend (or if we want, directly from the API)
+    function fetchData() {
+        fetch(
+            `${process.env.REACT_APP_API_URL}/propose-downstream?page=${page}&per_page=20`
+        )
+            .then((response) => response.json())
+            .then((data) => {
+                jsonToRow(data);
+                setLoaded(true);
+                setPage(page + 1); // set next page
+            })
+            .catch((err) => {
+                console.log(err);
+                setErrors(err);
+            });
+    }
+
+    // Convert fetched json into row format that the table can read
+    function jsonToRow(res) {
+        let rowsList = [];
+
+        res.map((propose_downstream) => {
+            let singleRow = {
+                cells: [
+                    {
+                        title: (
+                            <ForgeIcon url={propose_downstream.project_url} />
+                        ),
+                    },
+                    {
+                        title: (
+                            <strong>
+                                <TriggerLink builds={propose_downstream} />
+                            </strong>
+                        ),
+                    },
+                    {
+                        title: (
+                            <ProposeDownstreamStatuses
+                                statuses={
+                                    propose_downstream.status_per_downstream_pr
+                                }
+                                ids={
+                                    propose_downstream.packit_id_per_downstream_pr
+                                }
+                            />
+                        ),
+                    },
+                    {
+                        title: (
+                            <Timestamp
+                                stamp={propose_downstream.submitted_time}
+                            />
+                        ),
+                    },
+                ],
+            };
+            rowsList.push(singleRow);
+        });
+        setRows(rows.concat(rowsList));
+    }
+
+    function onSort(_event, index, direction) {
+        const sortedRows = rows.sort((a, b) =>
+            a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0
+        );
+        setSortBy({
+            index,
+            direction,
+        });
+        setRows(
+            direction === SortByDirection.asc
+                ? sortedRows
+                : sortedRows.reverse()
+        );
+    }
+
+    // Load more items
+    function nextPage() {
+        fetchData();
+    }
+
+    // Executes fetchData on first render of component
+    // look at detailed comment in ./copr_builds_table.js
+    useEffect(() => {
+        fetchData();
+    }, []);
+
+    // If backend API is down
+    if (hasError) {
+        return <ConnectionError />;
+    }
+
+    // Show preloader if waiting for API data
+    if (!loaded) {
+        return <Preloader />;
+    }
+
+    return (
+        <div>
+            <Table
+                aria-label="Sortable Table"
+                variant={TableVariant.compact}
+                sortBy={sortBy}
+                onSort={onSort}
+                cells={columns}
+                rows={rows}
+            >
+                <TableHeader />
+                <TableBody />
+            </Table>
+            <center>
+                <br />
+                <Button variant="control" onClick={nextPage}>
+                    Load More
+                </Button>
+            </center>
+        </div>
+    );
+};
+
+export default ProposeDownstreamsTable;

--- a/frontend/src/components/trigger_link.js
+++ b/frontend/src/components/trigger_link.js
@@ -1,5 +1,11 @@
 import React from "react";
-import { getPRLink, getHostName, getBranchLink } from "../utils/forge_urls";
+import {
+    getPRLink,
+    getHostName,
+    getBranchLink,
+    getIssueLink,
+    getReleaseLink,
+} from "../utils/forge_urls";
 
 const TriggerLink = (props) => {
     let link = "";
@@ -23,6 +29,15 @@ const TriggerLink = (props) => {
             props.builds.repo_name,
             props.builds.pr_id
         );
+    } else if (props.builds.issue_id) {
+        jobSuffix = `#${props.builds.issue_id}`;
+
+        link = getIssueLink(
+            getHostName(gitRepo),
+            props.builds.repo_namespace,
+            props.builds.repo_name,
+            props.builds.issue_id
+        );
     } else if (props.builds.branch_name) {
         jobSuffix = `:${props.builds.branch_name}`;
 
@@ -31,6 +46,15 @@ const TriggerLink = (props) => {
             props.builds.repo_namespace,
             props.builds.repo_name,
             props.builds.branch_name
+        );
+    } else if (props.builds.release) {
+        jobSuffix = `#release:${props.builds.release}`;
+
+        link = getReleaseLink(
+            getHostName(gitRepo),
+            props.builds.repo_namespace,
+            props.builds.repo_name,
+            props.builds.release
         );
     }
 

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -11,6 +11,7 @@ import { ResultsPageSRPM } from "./components/results/srpm";
 import { ResultsPageCopr } from "./components/results/copr";
 import { ResultsPageKoji } from "./components/results/koji";
 import { ResultsPageTestingFarm } from "./components/results/testing_farm";
+import { ResultsPageProposeDownstream } from "./components/results/propose_downstream";
 import { Forge } from "./components/forge";
 import Pipelines from "./components/pipelines";
 
@@ -93,6 +94,12 @@ const AppRoutes = () => (
             component={ResultsPageTestingFarm}
             exact
             title="Testing Farm Results"
+        />
+        <Route
+            path="/results/propose-downstream/:id"
+            component={ResultsPageProposeDownstream}
+            exact
+            title="Propose Results"
         />
         <Route path="/" component={NotFound} title="404 Page Not Found" />
     </Switch>

--- a/frontend/src/utils/forge_urls.js
+++ b/frontend/src/utils/forge_urls.js
@@ -38,4 +38,32 @@ function getBranchLink(forge, namespace, repoName, branchName) {
     return branchLink;
 }
 
-export { getHostName, getPRLink, getBranchLink };
+// getIssueLink - returns the issue link if possible otherwise an empty string
+function getIssueLink(forge, namespace, repoName, issueID) {
+    let issueLink = "";
+    switch (forge) {
+        case "github.com":
+            issueLink = `https://github.com/${namespace}/${repoName}/issues/${issueID}`;
+            break;
+        case "gitlab.com":
+            issueLink = `https://gitlab.com/${namespace}/${repoName}/issues/-/${issueID}`;
+            break;
+    }
+    return issueLink;
+}
+
+// getReleaseLink - returns the link to release if possible otherwise an empty string
+function getReleaseLink(forge, namespace, repoName, release) {
+    let releaseLink = "";
+    switch (forge) {
+        case "github.com":
+            releaseLink = `https://github.com/${namespace}/${repoName}/releases/tag/${release}`;
+            break;
+        case "gitlab.com":
+            releaseLink = `https://gitlab.com/${namespace}/${repoName}/-/tags/${release}`;
+            break;
+    }
+    return releaseLink;
+}
+
+export { getHostName, getPRLink, getBranchLink, getIssueLink, getReleaseLink };

--- a/packit_dashboard/api/routes.py
+++ b/packit_dashboard/api/routes.py
@@ -53,3 +53,11 @@ def project_releases(forge, namespace, repo_name):
 def project_issues(forge, namespace, repo_name):
     url = f"{API_URL}/projects/{forge}/{namespace}/{repo_name}/issues"
     return jsonify(return_json(url))
+
+
+@api.route("/api/propose-downstream/")
+def propose_downstream():
+    page = request.args.get("page")
+    per_page = request.args.get("per_page")
+    url = f"{API_URL}/propose-downstream?page={page}&per_page={per_page}"
+    return jsonify(return_json(url))

--- a/tests/data/propose-downstream_result_issue_trigger.json
+++ b/tests/data/propose-downstream_result_issue_trigger.json
@@ -1,0 +1,16 @@
+{
+  "status": "retry",
+  "branch": "fedora-rawhide-x86_64",
+  "downstream_pr_url": "",
+  "submitted_time": 1646654386,
+  "start_time": 1646654660,
+  "finished_time": 1646654752,
+  "logs": "",
+  "repo_namespace": "packit",
+  "repo_name": "packit",
+  "git_repo": "https://github.com/packit/packit",
+  "pr_id": null,
+  "issue_id": 235,
+  "branch_name": "main",
+  "release": null
+}

--- a/tests/data/propose-downstream_result_pr_trigger.json
+++ b/tests/data/propose-downstream_result_pr_trigger.json
@@ -1,0 +1,16 @@
+{
+  "status": "running",
+  "branch": "fedora-34-x86_64",
+  "downstream_pr_url": "",
+  "submitted_time": 1646654386,
+  "start_time": 1646654660,
+  "finished_time": 1646654752,
+  "logs": "",
+  "repo_namespace": "packit",
+  "repo_name": "packit",
+  "git_repo": "https://github.com/packit/packit",
+  "pr_id": 234,
+  "issue_id": null,
+  "branch_name": "main",
+  "release": null
+}

--- a/tests/data/propose-downstream_result_release_trigger.json
+++ b/tests/data/propose-downstream_result_release_trigger.json
@@ -1,0 +1,16 @@
+{
+  "status": "submitted",
+  "branch": "fedora-36-x86_64",
+  "downstream_pr_url": "https://src.fedoraproject.org/rpms/python-ogr/pull-request/286",
+  "submitted_time": 1646654386,
+  "start_time": 1646654660,
+  "finished_time": 1646654752,
+  "logs": "uzasne logy\na taky fest\ntajne\n",
+  "repo_namespace": "packit",
+  "repo_name": "packit",
+  "git_repo": "https://github.com/packit/packit",
+  "pr_id": null,
+  "issue_id": null,
+  "branch_name": "main",
+  "release": "0.1.0"
+}

--- a/tests/data/propose-downstream_table.json
+++ b/tests/data/propose-downstream_table.json
@@ -1,0 +1,79 @@
+[
+  {
+    "packit_id": 1,
+    "status": "packit-dev",
+    "submitted_time": "3634916",
+    "status_per_downstream_pr": {
+      "fedora-34-x86_64": "running",
+      "fedora-36-x86_64": "error",
+      "fedora-rawhide-x86_64": "retry",
+      "epel-8-x86_64": "submitted",
+      "fedora-35-x86_64": "queued"
+    },
+    "packit_id_per_downstream_pr": {
+      "fedora-34-x86_64": 1,
+      "fedora-36-x86_64": 2,
+      "fedora-rawhide-x86_64": 3,
+      "epel-8-x86_64": 4,
+      "fedora-35-x86_64": 5
+    },
+    "pr_id": 234,
+    "issue_id": null,
+    "release": null,
+    "repo_namespace": "packit",
+    "repo_name": "packit",
+    "project_url": "https://github.com/packit/packit"
+  },
+
+  {
+    "packit_id": 6,
+    "status": "packit-dev",
+    "submitted_time": "3634916",
+    "status_per_downstream_pr": {
+      "fedora-34-x86_64": "running",
+      "fedora-36-x86_64": "error",
+      "fedora-rawhide-x86_64": "retry",
+      "epel-8-x86_64": "submitted",
+      "fedora-35-x86_64": "queued"
+    },
+    "packit_id_per_downstream_pr": {
+      "fedora-34-x86_64": 6,
+      "fedora-36-x86_64": 7,
+      "fedora-rawhide-x86_64": 8,
+      "epel-8-x86_64": 9,
+      "fedora-35-x86_64": 10
+    },
+    "pr_id": null,
+    "issue_id": 235,
+    "release": null,
+    "repo_namespace": "packit",
+    "repo_name": "packit",
+    "project_url": "https://github.com/packit/packit"
+  },
+
+  {
+    "packit_id": 11,
+    "status": "packit-dev",
+    "submitted_time": "3634916",
+    "status_per_downstream_pr": {
+      "fedora-34-x86_64": "running",
+      "fedora-36-x86_64": "error",
+      "fedora-rawhide-x86_64": "retry",
+      "epel-8-x86_64": "submitted",
+      "fedora-35-x86_64": "queued"
+    },
+    "packit_id_per_downstream_pr": {
+      "fedora-34-x86_64": 11,
+      "fedora-36-x86_64": 12,
+      "fedora-rawhide-x86_64": 13,
+      "epel-8-x86_64": 14,
+      "fedora-35-x86_64": 15
+    },
+    "pr_id": null,
+    "issue_id": null,
+    "release": "0.46.0",
+    "repo_namespace": "packit",
+    "repo_name": "packit",
+    "project_url": "https://github.com/packit/packit"
+  }
+]


### PR DESCRIPTION
<!-- notes for reviewers -->

I also added fake data for propose-downstream job because dashboard-stg can't see propose-downstream jobs at all and I guess we will be developing the `Propose Downstream` part in dashboard in future. 
Current solution how to "insert" the fake data to dashboard-stg is really bad :grinning:  You need to pass this json file to corresponding `jsonToRow` function. e.g. [here](https://github.com/packit/dashboard/blob/main/frontend/src/components/tables/copr.js#L66)

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Propose downstream demo:

https://user-images.githubusercontent.com/70757578/157068611-10614fbe-e7af-44d3-a548-24527fe95ec8.mov


Successfully submitted target demo:

https://user-images.githubusercontent.com/70757578/157068651-fa16f24a-bb17-44fd-8b49-7bff045ab9ab.mov

Running target:
![propose-downstream-target](https://user-images.githubusercontent.com/70757578/157067889-3f2c6520-ab39-4081-a860-4a04e055915c.png)


Fixes #155 

Merge after [packit-service#1337](https://github.com/packit/packit-service/pull/1337)

---

<!-- release notes for changelog/blog follow -->
You can view information about ongoing propose-downstream jobs via our dashboard. 