### PR TITLE
Don't run npm install when installing dependencies

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,4 +17,6 @@ Merge before/after
 
 ---
 
-<!-- release notes for changelog/blog follow -->
+RELEASE NOTES BEGIN
+￼
+RELEASE NOTES END

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,18 +6,18 @@ ENV REACT_APP_API_URL ${REACT_APP_API_URL}
 
 ENV HOME=/home/packit_dashboard
 
-COPY ./files /src/files
+WORKDIR /src
 
-WORKDIR "/src"
+COPY files/ files/
 
 RUN ansible-playbook -vv -c local -i localhost, files/ansible/install-deps.yaml \
     && dnf clean all
 
-COPY ./packit_dashboard  /src/packit_dashboard
-COPY ./frontend /src/frontend
+COPY packit_dashboard/  packit_dashboard/
+COPY frontend/ frontend/
 
 
-RUN ansible-playbook -vv -c local -i localhost, ./files/ansible/recipe.yaml
+RUN ansible-playbook -vv -c local -i localhost, files/ansible/recipe.yaml
 
 EXPOSE 8443
 

--- a/files/ansible/install-deps.yaml
+++ b/files/ansible/install-deps.yaml
@@ -1,10 +1,10 @@
 ---
-- name: Install dependencies for packit_dashboard.
+- name: Install dependencies for packit_dashboard
   hosts: all
   vars:
     packit_dashboard_path: /src
   tasks:
-    - name: Install all RPM/Python/Node packages needed to run dashboard.
+    - name: Install all RPM/Python/Node packages needed to run dashboard
       dnf:
         name:
           - python3-pip
@@ -18,7 +18,3 @@
           - mod_ssl
           - nss_wrapper
         state: present
-
-    - name: npm install
-      npm:
-        path: "{{ packit_dashboard_path }}"


### PR DESCRIPTION
We do that also in [files/ansible/recipe.yaml](https://github.com/packit/dashboard/blob/main/files/ansible/recipe.yaml#L18) so this was probably copy-pasta left-over ?

After [bumping the base image to F35](https://github.com/packit/deployment/pull/306) it results in
```
npm ERR! enoent ENOENT: no such file or directory, open '/src/package.json'
```

@csomh I hope we will not need the same change you did in packit/packit-service#1363 also here. I see the similar pattern in [run_httpd.sh](https://github.com/packit/dashboard/blob/main/files/scripts/run_httpd.sh), [httpd_packit.conf](https://github.com/packit/dashboard/blob/main/files/cfg/httpd_packit.conf), [install-deps.yaml](https://github.com/packit/dashboard/blob/main/files/ansible/install-deps.yaml#L15)