### PR TITLE
Update the Node.js-stack to enable upgrading to F36

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,6 @@ RUN ansible-playbook -vv -c local -i localhost, files/ansible/install-deps.yaml 
 COPY packit_dashboard/  packit_dashboard/
 COPY frontend/ frontend/
 
-
 RUN ansible-playbook -vv -c local -i localhost, files/ansible/recipe.yaml
 
 EXPOSE 8443

--- a/files/ansible/install-deps.yaml
+++ b/files/ansible/install-deps.yaml
@@ -4,6 +4,11 @@
   vars:
     packit_dashboard_path: /src
   tasks:
+    - name: Enable nodejs:18
+      ansible.builtin.command:
+        cmd: dnf module enable -y nodejs:18/minimal
+        creates: /etc/dnf/modules.d/nodejs.module
+
     - name: Install all RPM/Python/Node packages needed to run dashboard
       dnf:
         name:

--- a/files/ansible/recipe.yaml
+++ b/files/ansible/recipe.yaml
@@ -18,6 +18,14 @@
         cmd: yarn install
 
     - name: bundle javascript
+      # TODO: remove this once the Node.js-stack stops using legacy crypto
+      environment:
+        NODE_OPTIONS: "--openssl-legacy-provider"
       command:
         chdir: "{{ packit_dashboard_path }}"
         cmd: yarn run build
+
+    - name: Clean up Node.js modules
+      ansible.builtin.file:
+        state: absent
+        path: "{{ packit_dashboard_path }}/node_modules"


### PR DESCRIPTION
In order to be able to upgrade the base image to Fedora Linux 36,
we need Node.js 18 and use --openssl-legacy-provider. Otherwise
'yarn run build' fails due to crypto issues.

Merge after #181 and after the base image was upgraded to Fedora Linux 36 and rebuilt.