### PR TITLE
Fix dashboard dependencies

### DIFF
--- a/files/ansible/install-deps.yaml
+++ b/files/ansible/install-deps.yaml
@@ -11,8 +11,7 @@
           - python3-flask
           - python3-requests
           - yarnpkg
-          - npm
-          - nss_wrapper
+          - nodejs
           - python3-mod_wsgi
           - mod_ssl
         state: present


### PR DESCRIPTION
Remove yet another nss_wrapper and install nodejs instead of npm, which
was replaced by yarn.

Leftover from #181.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>