### PR TITLE
Fix the server name in prod

### DIFF
--- a/files/scripts/run_httpd.sh
+++ b/files/scripts/run_httpd.sh
@@ -2,13 +2,18 @@
 
 set -eux
 
+INSTANCE=
+if [ -n "${DEPLOYMENT}" ] && [ "${DEPLOYMENT}" != "prod" ]; then
+    INSTANCE=".${DEPLOYMENT}"
+fi
+
 exec mod_wsgi-express-3 start-server \
     --https-port 8443 \
     --access-log \
     --log-to-terminal \
     --ssl-certificate-file /secrets/fullchain.pem \
     --ssl-certificate-key-file /secrets/privkey.pem \
-    --server-name dashboard.${DEPLOYMENT}.packit.dev \
+    --server-name dashboard${INSTANCE}.packit.dev \
     --processes 2 \
     --locale "C.UTF-8" \
     /usr/share/packit_dashboard/packit_dashboard.wsgi


### PR DESCRIPTION
The server name in prod has no instance slug.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>