### PR TITLE
Display multiple Copr builds for TF results if present

### DIFF
--- a/frontend/src/components/results/testing_farm.js
+++ b/frontend/src/components/results/testing_farm.js
@@ -68,20 +68,35 @@ const ResultsPageTestingFarm = (props) => {
         <>{data.status}</>
     );
 
-    const coprBuildInfo = data.copr_build_id ? (
-        <tr>
-            <td>
-                <strong>COPR build</strong>
-            </td>
-            <td>
-                <a href={`/results/copr-builds/${data.copr_build_id}`}>
-                    Details
-                </a>
-            </td>
-        </tr>
-    ) : (
-        ""
-    );
+    function getCoprBuilds() {
+        let coprBuilds = [];
+        let title =
+            data.copr_build_ids.length == 1 ? "Copr build" : "Copr builds";
+
+        for (var i = 0; i < data.copr_build_ids.length; i++) {
+            var coprBuildId = data.copr_build_ids[i];
+            var linkText =
+                data.copr_build_ids.length == 1
+                    ? "Details"
+                    : `Build ${i + 1}  `;
+            coprBuilds.push(
+                <Label href={`/results/copr-builds/${coprBuildId}`}>
+                    {linkText}
+                </Label>
+            );
+        }
+
+        return (
+            <tr>
+                <td>
+                    <strong>{title}</strong>
+                </td>
+                <td>{coprBuilds}</td>
+            </tr>
+        );
+    }
+
+    const coprBuildInfo = data.copr_build_ids.length > 0 ? getCoprBuilds() : "";
 
     return (
         <div>


### PR DESCRIPTION
In packit/packit-service#1658 there was implemented that a TF run can be triggered with multiple Copr builds and API for TF runs changed (copr_build_id -> copr_build_ids) as well. This PR implements displaying those builds correctly in the TF result view.


Related to packit/packit-service#1658
 
The view for the TF runs with only one build stays the same and this is how it looks like for TF runs with more builds:
![Snímka obrazovky z 2022-09-29 14-03-18](https://user-images.githubusercontent.com/49026743/193031656-23a805fa-c87c-4d79-b718-9a99ce440e6e.png)



---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
