### PR TITLE
Enforce HTTPS with HSTS

### DIFF
--- a/files/scripts/run_httpd.sh
+++ b/files/scripts/run_httpd.sh
@@ -7,10 +7,17 @@ if [ -n "${DEPLOYMENT}" ] && [ "${DEPLOYMENT}" != "prod" ]; then
     INSTANCE=".${DEPLOYMENT}"
 fi
 
+# See "mod_wsgi-express-3 start-server --help" for details on
+# these options, and the configuration documentation of mod_wsgi:
+# https://modwsgi.readthedocs.io/en/master/configuration.html
+# For the HSTS policy see
+# https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
 exec mod_wsgi-express-3 start-server \
-    --https-port 8443 \
     --access-log \
     --log-to-terminal \
+    --https-port 8443 \
+    --https-only \
+    --hsts-policy "max-age=31536000;includeSubDomains" \
     --ssl-certificate-file /secrets/fullchain.pem \
     --ssl-certificate-key-file /secrets/privkey.pem \
     --server-name dashboard${INSTANCE}.packit.dev \


### PR DESCRIPTION
```
$ mod_wsgi-express-3 start-server --help
--https-only          Flag indicating whether any requests made using a HTTP
                      request over the non secure connection should be
                      redirected automatically to use a HTTPS request over
                      the secure connection.
--hsts-policy PARAMS  Specify the HSTS policy that should be applied when
                      HTTPS only connections are being enforced.
```
https://en.wikipedia.org/wiki/HTTP_Strict_Transport_Security
https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html

Enterprise Security Standard (ESSv9) requirement.