### PR TITLE
fix(results,tf): ignore ‹null›s as Copr builds

### DIFF
--- a/frontend/src/components/results/testing_farm.js
+++ b/frontend/src/components/results/testing_farm.js
@@ -96,6 +96,7 @@ const ResultsPageTestingFarm = (props) => {
         );
     }
 
+    data.copr_build_ids = data.copr_build_ids.filter((copr) => copr !== null);
     const coprBuildInfo = data.copr_build_ids.length > 0 ? getCoprBuilds() : "";
 
     return (


### PR DESCRIPTION
When receiving TF results from Packit API endpoint, ignore ‹null›s as Copr build, so that we don't have a link to Copr build consisting of ‹null›.

Signed-off-by: Matej Focko <mfocko@redhat.com>

Fixes #198

---

RELEASE NOTES BEGIN
We have fixed a bug in dashboard that linked `null` as a Copr build for Testing Farm runs that do not require any Copr build.
RELEASE NOTES END
