### PR TITLE
fix: router params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,3 +112,6 @@ package-lock.json
 
 # Requre debug logs
 modules.out
+
+# Makefile cache
+.install-logos

--- a/frontend/src/components/forge.js
+++ b/frontend/src/components/forge.js
@@ -9,9 +9,10 @@ import {
 
 import ProjectsList from "./projects_list";
 import ForgeIcon from "./forge_icon";
+import { useParams } from "react-router-dom";
 
-const Forge = (props) => {
-    let forge = props.match.params.forge;
+const Forge = () => {
+    let { forge } = useParams();
 
     return (
         <div>

--- a/frontend/src/components/namespace.js
+++ b/frontend/src/components/namespace.js
@@ -9,10 +9,10 @@ import {
 
 import ForgeIcon from "./forge_icon";
 import ProjectsList from "./projects_list";
+import { useParams } from "react-router-dom";
 
-const Namespace = (props) => {
-    let forge = props.match.params.forge;
-    let namespace = props.match.params.namespace;
+const Namespace = () => {
+    let { forge, namespace } = useParams();
 
     return (
         <div>

--- a/frontend/src/components/project_info.js
+++ b/frontend/src/components/project_info.js
@@ -23,11 +23,10 @@ import Preloader from "./preloader";
 import ForgeIcon from "./forge_icon";
 
 import { ExternalLinkAltIcon } from "@patternfly/react-icons";
+import { useParams } from "react-router-dom";
 
-const ProjectInfo = (props) => {
-    let forge = props.match.params.forge;
-    let namespace = props.match.params.namespace;
-    let repoName = props.match.params.repoName;
+const ProjectInfo = () => {
+    let { forge, namespace, repoName } = useParams();
 
     const [activeTabKey, setActiveTabKey] = React.useState(0);
     const [hasError, setErrors] = useState(false);

--- a/frontend/src/components/results/copr.js
+++ b/frontend/src/components/results/copr.js
@@ -14,9 +14,10 @@ import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { StatusLabel } from "../status_labels";
 import { Timestamp } from "../../utils/time";
+import { useParams } from "react-router-dom";
 
-const ResultsPageCopr = (props) => {
-    let id = props.match.params.id;
+const ResultsPageCopr = () => {
+    let { id } = useParams();
 
     const [hasError, setErrors] = useState(false);
     const [loaded, setLoaded] = useState(false);

--- a/frontend/src/components/results/koji.js
+++ b/frontend/src/components/results/koji.js
@@ -14,9 +14,10 @@ import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { StatusLabel } from "../status_labels";
 import { Timestamp } from "../../utils/time";
+import { useParams } from "react-router-dom";
 
-const ResultsPageKoji = (props) => {
-    let id = props.match.params.id;
+const ResultsPageKoji = () => {
+    let { id } = useParams();
 
     const [hasError, setErrors] = useState(false);
     const [loaded, setLoaded] = useState(false);

--- a/frontend/src/components/results/propose_downstream.js
+++ b/frontend/src/components/results/propose_downstream.js
@@ -18,9 +18,10 @@ import TriggerLink from "../trigger_link";
 import { ProposeDownstreamTargetStatusLabel } from "../status_labels";
 import { Timestamp } from "../../utils/time";
 import { LogViewer, LogViewerSearch } from "@patternfly/react-log-viewer";
+import { useParams } from "react-router-dom";
 
-const ResultsPageProposeDownstream = (props) => {
-    let id = props.match.params.id;
+const ResultsPageProposeDownstream = () => {
+    let { id } = useParams();
 
     const [hasError, setErrors] = useState(false);
     const [loaded, setLoaded] = useState(false);

--- a/frontend/src/components/results/srpm.js
+++ b/frontend/src/components/results/srpm.js
@@ -18,9 +18,10 @@ import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { StatusLabel, toSRPMStatus } from "../status_labels";
 import { Timestamp } from "../../utils/time";
+import { useParams } from "react-router-dom";
 
-const ResultsPageSRPM = (props) => {
-    let id = props.match.params.id;
+const ResultsPageSRPM = () => {
+    let { id } = useParams();
 
     const [hasError, setErrors] = useState(false);
     const [loaded, setLoaded] = useState(false);

--- a/frontend/src/components/results/testing_farm.js
+++ b/frontend/src/components/results/testing_farm.js
@@ -15,9 +15,10 @@ import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { TFStatusLabel } from "../status_labels";
 import { Timestamp } from "../../utils/time";
+import { useParams } from "react-router-dom";
 
-const ResultsPageTestingFarm = (props) => {
-    let id = props.match.params.id;
+const ResultsPageTestingFarm = () => {
+    let { id } = useParams();
 
     const [hasError, setErrors] = useState(false);
     const [loaded, setLoaded] = useState(false);


### PR DESCRIPTION
When we merged the refactor and updating of dependencies the way that
routes are handled changed as well due to major version upgrade for
React router. This has now been fixed by using useParams() instead of
props component parameter

closes #204

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Fix router parameters no longer working after updating dependencies
RELEASE NOTES END
