### PR TITLE
refactor: fix eslint issues

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,9 +24,15 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint ."
   },
   "eslintConfig": {
+    "ignorePatterns": [
+      "build/*",
+      "public/*",
+      "frontend/*"
+    ],
     "extends": [
       "react-app",
       "react-app/jest"

--- a/frontend/src/components/app_layout.js
+++ b/frontend/src/components/app_layout.js
@@ -68,7 +68,11 @@ const AppLayout = ({ children }) => {
                     <a href="https://packit.dev/posts">Blog posts</a>
                 </NavItem>
                 <NavItem key="faq-page" id="faq-page">
-                    <a target="_blank" href="https://packit.dev/docs/faq">
+                    <a
+                        target="_blank"
+                        href="https://packit.dev/docs/faq"
+                        rel="noreferrer"
+                    >
                         FAQ
                     </a>
                 </NavItem>

--- a/frontend/src/components/branch.js
+++ b/frontend/src/components/branch.js
@@ -46,6 +46,7 @@ const BranchList = (props) => {
     // look at detailed comment in ./copr_builds_table.js
     useEffect(() => {
         fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     function onToggle(branchName) {

--- a/frontend/src/components/forge.js
+++ b/frontend/src/components/forge.js
@@ -1,10 +1,9 @@
-import React, { useState } from "react";
+import React from "react";
 import {
     PageSection,
     PageSectionVariants,
     TextContent,
     Text,
-    Label,
 } from "@patternfly/react-core";
 
 import ProjectsList from "./projects_list";

--- a/frontend/src/components/issues.js
+++ b/frontend/src/components/issues.js
@@ -36,6 +36,7 @@ const IssuesList = (props) => {
     // look at detailed comment in ./copr_builds_table.js
     useEffect(() => {
         fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // If backend API is down

--- a/frontend/src/components/namespace.js
+++ b/frontend/src/components/namespace.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import {
     PageSection,
     PageSectionVariants,

--- a/frontend/src/components/pr.js
+++ b/frontend/src/components/pr.js
@@ -49,6 +49,7 @@ const PullRequestList = (props) => {
     // look at detailed comment in ./copr_builds_table.js
     useEffect(() => {
         fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     function onToggle(prID) {

--- a/frontend/src/components/project_info.js
+++ b/frontend/src/components/project_info.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import {
     PageSection,
     PageSectionVariants,
@@ -9,7 +9,6 @@ import {
     TabTitleText,
     Card,
     CardBody,
-    Divider,
     TextContent,
     Label,
 } from "@patternfly/react-core";
@@ -37,7 +36,7 @@ const ProjectInfo = () => {
         setActiveTabKey(tabIndex);
     };
 
-    function checkValidProject() {
+    const checkValidProject = useCallback(() => {
         fetch(
             `${process.env.REACT_APP_API_URL}/projects/${forge}/${namespace}/${repoName}`
         )
@@ -53,12 +52,12 @@ const ProjectInfo = () => {
                 console.log(err);
                 setErrors(err);
             });
-    }
+    }, [forge, namespace, repoName]);
 
     // Executes checkValidProject on first render of component
     useEffect(() => {
         checkValidProject();
-    }, []);
+    }, [checkValidProject]);
 
     let details = <div></div>;
 

--- a/frontend/src/components/projects_list.js
+++ b/frontend/src/components/projects_list.js
@@ -30,7 +30,7 @@ const ProjectsList = (props) => {
     const [page, setPage] = useState(1);
     const [projects, setProjects] = useState([]);
     // by default, ignore non useful projects ie without any handled item
-    const [showUseful, setShowUseful] = useState(true);
+    const showUseful = true;
 
     // If a namespace and forge are provided, then load those
     // otherwise load all projects
@@ -84,6 +84,7 @@ const ProjectsList = (props) => {
     // here useEffect gets executed after page changes and it fetched more pages
     useEffect(() => {
         fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [page]);
 
     function loadMore() {
@@ -131,7 +132,11 @@ const ProjectsList = (props) => {
                                     {`${project.namespace}/${project.repo_name}`}
                                 </Link>
                                 <br />
-                                <a href={project.project_url} target="_blank">
+                                <a
+                                    href={project.project_url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
                                     <ExternalLinkAltIcon />
                                 </a>
                             </CardTitle>

--- a/frontend/src/components/releases.js
+++ b/frontend/src/components/releases.js
@@ -3,8 +3,6 @@ import React, { useState, useEffect } from "react";
 import ConnectionError from "./error";
 import Preloader from "./preloader";
 
-import { List, ListItem } from "@patternfly/react-core";
-
 const ReleasesList = (props) => {
     // Local State
     const [hasError, setErrors] = useState(false);
@@ -36,6 +34,7 @@ const ReleasesList = (props) => {
     // look at detailed comment in ./copr_builds_table.js
     useEffect(() => {
         fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // If backend API is down
@@ -65,7 +64,7 @@ const ReleasesList = (props) => {
                         </th>
                     </tr>
                 </thead>
-                <tbody role="rowgroup">
+                <tbody>
                     {releaseList.map((release, index) => (
                         <tr role="row" key={index}>
                             <td role="cell" data-label="Tag">

--- a/frontend/src/components/results/copr.js
+++ b/frontend/src/components/results/copr.js
@@ -34,7 +34,7 @@ const ResultsPageCopr = () => {
                 console.log(err);
                 setErrors(err);
             });
-    }, []);
+    }, [id]);
 
     // If backend API is down
     if (hasError) {
@@ -66,11 +66,11 @@ const ResultsPageCopr = () => {
         let packagesToInstall = [];
 
         for (let packageDict of data.built_packages) {
-            if (packageDict.arch != "src") {
+            if (packageDict.arch !== "src") {
                 const packageString =
                     packageDict.name +
                     "-" +
-                    (packageDict.epoch != 0 ? packageDict.epoch + ":" : "") +
+                    (packageDict.epoch !== 0 ? packageDict.epoch + ":" : "") +
                     packageDict.version +
                     "-" +
                     packageDict.release +
@@ -91,7 +91,7 @@ const ResultsPageCopr = () => {
     );
 
     const installationInstructions =
-        data.status == "success" ? (
+        data.status === "success" ? (
             <Card>
                 <CardBody>
                     <Text component="p">
@@ -156,7 +156,7 @@ const ResultsPageCopr = () => {
                             role="grid"
                             aria-label="Builds Table"
                         >
-                            <tbody role="rowgroup">
+                            <tbody>
                                 <tr>
                                     <td>
                                         <strong>SRPM Build</strong>

--- a/frontend/src/components/results/koji.js
+++ b/frontend/src/components/results/koji.js
@@ -34,7 +34,7 @@ const ResultsPageKoji = () => {
                 console.log(err);
                 setErrors(err);
             });
-    }, []);
+    }, [id]);
 
     // If backend API is down
     if (hasError) {
@@ -89,7 +89,7 @@ const ResultsPageKoji = () => {
                             role="grid"
                             aria-label="Builds Table"
                         >
-                            <tbody role="rowgroup">
+                            <tbody>
                                 <tr>
                                     <td>
                                         <strong>SRPM Build</strong>

--- a/frontend/src/components/results/propose_downstream.js
+++ b/frontend/src/components/results/propose_downstream.js
@@ -38,7 +38,7 @@ const ResultsPageProposeDownstream = () => {
                 console.log(err);
                 setErrors(err);
             });
-    }, []);
+    }, [id]);
 
     // If backend API is down
     if (hasError) {
@@ -121,7 +121,7 @@ const ResultsPageProposeDownstream = () => {
                             role="grid"
                             aria-label="Propose table"
                         >
-                            <tbody role="rowgroup">
+                            <tbody>
                                 <tr>
                                     <td>
                                         <strong>Status</strong>

--- a/frontend/src/components/results/srpm.js
+++ b/frontend/src/components/results/srpm.js
@@ -16,7 +16,7 @@ import { LogViewer, LogViewerSearch } from "@patternfly/react-log-viewer";
 import ConnectionError from "../error";
 import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
-import { StatusLabel, toSRPMStatus } from "../status_labels";
+import { StatusLabel } from "../status_labels";
 import { Timestamp } from "../../utils/time";
 import { useParams } from "react-router-dom";
 
@@ -38,7 +38,7 @@ const ResultsPageSRPM = () => {
                 console.log(err);
                 setErrors(err);
             });
-    }, []);
+    }, [id]);
 
     // If backend API is down
     if (hasError) {

--- a/frontend/src/components/results/testing_farm.js
+++ b/frontend/src/components/results/testing_farm.js
@@ -14,7 +14,6 @@ import ConnectionError from "../error";
 import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { TFStatusLabel } from "../status_labels";
-import { Timestamp } from "../../utils/time";
 import { useParams } from "react-router-dom";
 
 const ResultsPageTestingFarm = () => {
@@ -35,7 +34,7 @@ const ResultsPageTestingFarm = () => {
                 console.log(err);
                 setErrors(err);
             });
-    }, []);
+    }, [id]);
 
     // If backend API is down
     if (hasError) {
@@ -72,12 +71,12 @@ const ResultsPageTestingFarm = () => {
     function getCoprBuilds() {
         let coprBuilds = [];
         let title =
-            data.copr_build_ids.length == 1 ? "Copr build" : "Copr builds";
+            data.copr_build_ids.length === 1 ? "Copr build" : "Copr builds";
 
         for (var i = 0; i < data.copr_build_ids.length; i++) {
             var coprBuildId = data.copr_build_ids[i];
             var linkText =
-                data.copr_build_ids.length == 1
+                data.copr_build_ids.length === 1
                     ? "Details"
                     : `Build ${i + 1}  `;
             coprBuilds.push(
@@ -127,7 +126,7 @@ const ResultsPageTestingFarm = () => {
                             role="grid"
                             aria-label="Testing farm table"
                         >
-                            <tbody role="rowgroup">
+                            <tbody>
                                 <tr>
                                     <td>
                                         <strong>Status</strong>

--- a/frontend/src/components/tables/copr.js
+++ b/frontend/src/components/tables/copr.js
@@ -10,7 +10,7 @@ import {
     cellWidth,
 } from "@patternfly/react-table";
 
-import { Button, Label, Tooltip } from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core";
 import TriggerLink from "../trigger_link";
 import ConnectionError from "../error";
 import Preloader from "../preloader";
@@ -40,7 +40,7 @@ const ChrootStatuses = (props) => {
 
 const CoprBuildsTable = () => {
     // Headings
-    const column_list = [
+    const columns = [
         { title: "", transforms: [cellWidth(5)] }, // space for forge icon
         { title: "Trigger", transforms: [cellWidth(15)] },
         { title: "Chroots", transforms: [cellWidth(60)] },
@@ -49,7 +49,6 @@ const CoprBuildsTable = () => {
     ];
 
     // Local State
-    const [columns, setColumns] = useState(column_list);
     const [rows, setRows] = useState([]);
     const [hasError, setErrors] = useState(false);
     const [loaded, setLoaded] = useState(false);
@@ -77,7 +76,7 @@ const CoprBuildsTable = () => {
     function jsonToRow(res) {
         let rowsList = [];
 
-        res.map((copr_builds) => {
+        res.forEach((copr_builds) => {
             let singleRow = {
                 cells: [
                     {
@@ -108,7 +107,11 @@ const CoprBuildsTable = () => {
                     {
                         title: (
                             <strong>
-                                <a href={copr_builds.web_url} target="_blank">
+                                <a
+                                    href={copr_builds.web_url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
                                     {copr_builds.build_id}
                                 </a>
                             </strong>
@@ -154,6 +157,7 @@ const CoprBuildsTable = () => {
 
     useEffect(() => {
         fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // If backend API is down

--- a/frontend/src/components/tables/koji.js
+++ b/frontend/src/components/tables/koji.js
@@ -10,7 +10,7 @@ import {
     cellWidth,
 } from "@patternfly/react-table";
 
-import { Button, Label, Tooltip } from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core";
 import TriggerLink from "../trigger_link";
 import ConnectionError from "../error";
 import Preloader from "../preloader";
@@ -20,7 +20,7 @@ import { Timestamp } from "../../utils/time";
 
 const KojiBuildsTable = () => {
     // Headings
-    const column_list = [
+    const columns = [
         { title: "", transforms: [cellWidth(5)] }, // space for forge icon
         { title: "Trigger", transforms: [cellWidth(35)] },
         { title: "Target", transforms: [sortable, cellWidth(20)] },
@@ -29,7 +29,6 @@ const KojiBuildsTable = () => {
     ];
 
     // Local State
-    const [columns, setColumns] = useState(column_list);
     const [rows, setRows] = useState([]);
     const [hasError, setErrors] = useState(false);
     const [loaded, setLoaded] = useState(false);
@@ -57,7 +56,7 @@ const KojiBuildsTable = () => {
     function jsonToRow(res) {
         let rowsList = [];
 
-        res.map((koji_builds) => {
+        res.forEach((koji_builds) => {
             let singleRow = {
                 cells: [
                     {
@@ -89,7 +88,11 @@ const KojiBuildsTable = () => {
                     {
                         title: (
                             <strong>
-                                <a href={koji_builds.web_url} target="_blank">
+                                <a
+                                    href={koji_builds.web_url}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
                                     {koji_builds.build_id}
                                 </a>
                             </strong>
@@ -122,6 +125,7 @@ const KojiBuildsTable = () => {
     // look at detailed comment in ./copr_builds_table.js
     useEffect(() => {
         fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // If backend API is down

--- a/frontend/src/components/tables/pipelines.js
+++ b/frontend/src/components/tables/pipelines.js
@@ -10,14 +10,13 @@ import {
     cellWidth,
 } from "@patternfly/react-table";
 
-import { Button, Label, LabelGroup, Tooltip } from "@patternfly/react-core";
+import { Button, LabelGroup } from "@patternfly/react-core";
 import TriggerLink from "../trigger_link";
 import ConnectionError from "../error";
 import Preloader from "../preloader";
 import ForgeIcon from "../forge_icon";
 import {
     StatusLabel,
-    toSRPMStatus,
     TFStatusLabel,
     ProposeDownstreamTargetStatusLabel,
 } from "../status_labels";
@@ -61,10 +60,10 @@ function getBuilderLabel(run) {
     let icon = undefined;
 
     if (run.copr.length > 0) {
-        icon = <img style={iconStyle} src={coprLogo} />;
+        icon = <img style={iconStyle} src={coprLogo} alt="Copr logo" />;
         text = "Copr";
     } else if (run.koji.length > 0) {
-        icon = <img style={iconStyle} src={kojiLogo} />;
+        icon = <img style={iconStyle} src={kojiLogo} alt="Koji logo" />;
         text = "Koji";
     }
 
@@ -77,7 +76,7 @@ function getBuilderLabel(run) {
 
 const PipelinesTable = () => {
     // Headings
-    const column_list = [
+    const columns = [
         { title: "", transforms: [cellWidth(5)] }, // space for forge icon
         { title: "Trigger", transforms: [cellWidth(15)] },
         { title: "Time Submitted", transforms: [sortable, cellWidth(10)] },
@@ -85,7 +84,6 @@ const PipelinesTable = () => {
     ];
 
     // Local State
-    const [columns, setColumns] = useState(column_list);
     const [rows, setRows] = useState([]);
     const [hasError, setErrors] = useState(false);
     const [loaded, setLoaded] = useState(false);
@@ -111,7 +109,7 @@ const PipelinesTable = () => {
     function jsonToRow(res) {
         let rowsList = [];
 
-        res.map((run) => {
+        res.forEach((run) => {
             let singleRow = {
                 cells: [
                     {
@@ -192,6 +190,7 @@ const PipelinesTable = () => {
 
     useEffect(() => {
         fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // If backend API is down

--- a/frontend/src/components/tables/propose_downstream.js
+++ b/frontend/src/components/tables/propose_downstream.js
@@ -39,7 +39,7 @@ const ProposeDownstreamStatuses = (props) => {
 
 const ProposeDownstreamsTable = () => {
     // Headings
-    const column_list = [
+    const columns = [
         { title: "", transforms: [cellWidth(5)] }, // space for forge icon
         { title: "Trigger", transforms: [cellWidth(25)] },
         { title: "Targets", transforms: [cellWidth(60)] },
@@ -47,7 +47,6 @@ const ProposeDownstreamsTable = () => {
     ];
 
     // Local State
-    const [columns, setColumns] = useState(column_list);
     const [rows, setRows] = useState([]);
     const [hasError, setErrors] = useState(false);
     const [loaded, setLoaded] = useState(false);
@@ -75,7 +74,7 @@ const ProposeDownstreamsTable = () => {
     function jsonToRow(res) {
         let rowsList = [];
 
-        res.map((propose_downstream) => {
+        res.forEach((propose_downstream) => {
             let singleRow = {
                 cells: [
                     {
@@ -140,6 +139,7 @@ const ProposeDownstreamsTable = () => {
     // look at detailed comment in ./copr_builds_table.js
     useEffect(() => {
         fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // If backend API is down

--- a/frontend/src/components/tables/srpm.js
+++ b/frontend/src/components/tables/srpm.js
@@ -5,7 +5,6 @@ import {
     TableHeader,
     TableBody,
     TableVariant,
-    sortable,
     SortByDirection,
     cellWidth,
 } from "@patternfly/react-table";
@@ -16,12 +15,12 @@ import ConnectionError from "../error";
 import TriggerLink from "../trigger_link";
 import Preloader from "../preloader";
 import ForgeIcon from "../forge_icon";
-import { StatusLabel, toSRPMStatus } from "../status_labels";
+import { StatusLabel } from "../status_labels";
 import { Timestamp } from "../../utils/time";
 
 const SRPMBuildstable = () => {
     // Headings
-    const column_list = [
+    const columns = [
         { title: "", transforms: [cellWidth(5)] }, // space for forge icon
         { title: "Trigger", transforms: [cellWidth(55)] },
         { title: "Results", transforms: [cellWidth(20)] },
@@ -29,7 +28,6 @@ const SRPMBuildstable = () => {
     ];
 
     // Local State
-    const [columns, setColumns] = useState(column_list);
     const [rows, setRows] = useState([]);
     const [hasError, setErrors] = useState(false);
     const [loaded, setLoaded] = useState(false);
@@ -57,7 +55,7 @@ const SRPMBuildstable = () => {
     function jsonToRow(res) {
         let rowsList = [];
 
-        res.map((srpm_builds) => {
+        res.forEach((srpm_builds) => {
             let singleRow = {
                 cells: [
                     {
@@ -111,6 +109,7 @@ const SRPMBuildstable = () => {
     // look at detailed comment in ./copr_builds_table.js
     useEffect(() => {
         fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // If backend API is down

--- a/frontend/src/components/tables/testing_farm.js
+++ b/frontend/src/components/tables/testing_farm.js
@@ -10,7 +10,7 @@ import {
     cellWidth,
 } from "@patternfly/react-table";
 
-import { Button, Label, Tooltip } from "@patternfly/react-core";
+import { Button } from "@patternfly/react-core";
 
 import ConnectionError from "../error";
 import Preloader from "../preloader";
@@ -20,7 +20,7 @@ import { TFStatusLabel } from "../status_labels";
 import { Timestamp } from "../../utils/time";
 
 const TestingFarmResultsTable = () => {
-    const column_list = [
+    const columns = [
         { title: "", transforms: [cellWidth(5)] }, // space for forge icon
         { title: "Trigger", transforms: [cellWidth(35)] },
         { title: "Target", transforms: [sortable, cellWidth(20)] },
@@ -29,7 +29,6 @@ const TestingFarmResultsTable = () => {
     ];
 
     // Local State
-    const [columns, setColumns] = useState(column_list);
     const [rows, setRows] = useState([]);
     const [hasError, setErrors] = useState(false);
     const [loaded, setLoaded] = useState(false);
@@ -55,7 +54,7 @@ const TestingFarmResultsTable = () => {
 
     function jsonToRow(res) {
         let rowsList = [];
-        res.map((test_results) => {
+        res.forEach((test_results) => {
             let singleRow = {
                 cells: [
                     {
@@ -132,6 +131,7 @@ const TestingFarmResultsTable = () => {
     // look at detailed comment in ./copr_builds_table.js
     useEffect(() => {
         fetchData();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
 
     // If backend API is down
@@ -165,20 +165,6 @@ const TestingFarmResultsTable = () => {
             </center>
         </div>
     );
-};
-
-const TFLogsURL = (props) => {
-    // when the testing farm test is running, there is no url stored
-    // so instead of showing a fake link that leads to 404, do not show the link at all
-    if (props.link !== null) {
-        return (
-            <a target="_blank" href={props.link}>
-                {props.pipeline}
-            </a>
-        );
-    } else {
-        return <span>{props.pipeline}</span>;
-    }
 };
 
 export default TestingFarmResultsTable;

--- a/frontend/src/components/trigger_info.js
+++ b/frontend/src/components/trigger_info.js
@@ -25,7 +25,7 @@ const TriggerInfo = (props) => {
     // NOTE: Since we did not need any advanced table features,
     // I used a regular html table instead of Patternfly React's table component
     let activeViewContent;
-    if (activeView == "Builds") {
+    if (activeView === "Builds") {
         activeViewContent = (
             <div>
                 <table
@@ -49,7 +49,7 @@ const TriggerInfo = (props) => {
                             </th>
                         </tr>
                     </thead>
-                    <tbody role="rowgroup">
+                    <tbody>
                         {props.trigger.builds.map((build, index) => (
                             <tr role="row" key={index}>
                                 <td role="cell" data-label="Build ID">
@@ -71,7 +71,7 @@ const TriggerInfo = (props) => {
             </div>
         );
     }
-    if (activeView == "SRPM Builds") {
+    if (activeView === "SRPM Builds") {
         activeViewContent = (
             <div>
                 <table
@@ -92,7 +92,7 @@ const TriggerInfo = (props) => {
                             </th>
                         </tr>
                     </thead>
-                    <tbody role="rowgroup">
+                    <tbody>
                         {props.trigger.srpm_builds.map((build, index) => (
                             <tr role="row" key={index}>
                                 <td role="cell" data-label="SRPM Build ID">
@@ -111,7 +111,7 @@ const TriggerInfo = (props) => {
             </div>
         );
     }
-    if (activeView == "Test Runs") {
+    if (activeView === "Test Runs") {
         activeViewContent = (
             <div>
                 <table
@@ -135,7 +135,7 @@ const TriggerInfo = (props) => {
                             </th>
                         </tr>
                     </thead>
-                    <tbody role="rowgroup">
+                    <tbody>
                         {props.trigger.tests.map((test, index) => (
                             <tr role="row">
                                 <td role="cell" data-label="Pipeline ID">

--- a/frontend/src/components/trigger_link.js
+++ b/frontend/src/components/trigger_link.js
@@ -60,7 +60,7 @@ const TriggerLink = (props) => {
 
     if (link !== "") {
         return (
-            <a target="_blank" href={link}>
+            <a target="_blank" href={link} rel="noreferrer">
                 {props.builds.repo_namespace}/{props.builds.repo_name}
                 {jobSuffix}
             </a>

--- a/frontend/src/utils/forge_urls.js
+++ b/frontend/src/utils/forge_urls.js
@@ -20,6 +20,8 @@ function getPRLink(forge, namespace, repoName, prID) {
         case "gitlab.com":
             prLink = `https://gitlab.com/${namespace}/${repoName}/-/merge_requests/${prID}`;
             break;
+        default:
+            break;
     }
     return prLink;
 }
@@ -33,6 +35,8 @@ function getBranchLink(forge, namespace, repoName, branchName) {
             break;
         case "gitlab.com":
             branchLink = `https://gitlab.com/${namespace}/${repoName}/-/tree/${branchName}`;
+            break;
+        default:
             break;
     }
     return branchLink;
@@ -48,6 +52,8 @@ function getIssueLink(forge, namespace, repoName, issueID) {
         case "gitlab.com":
             issueLink = `https://gitlab.com/${namespace}/${repoName}/issues/-/${issueID}`;
             break;
+        default:
+            break;
     }
     return issueLink;
 }
@@ -61,6 +67,8 @@ function getReleaseLink(forge, namespace, repoName, release) {
             break;
         case "gitlab.com":
             releaseLink = `https://gitlab.com/${namespace}/${repoName}/-/tags/${release}`;
+            break;
+        default:
             break;
     }
     return releaseLink;

--- a/frontend/src/utils/time.js
+++ b/frontend/src/utils/time.js
@@ -1,4 +1,4 @@
-import { Text, Tooltip } from "@patternfly/react-core";
+import { Tooltip } from "@patternfly/react-core";
 
 /*
  * Get a pretty string like 'an hour ago', 'yesterday', '3 months ago',
@@ -12,7 +12,7 @@ const prettyTimeDifference = (difference) => {
     let numericPart = dayDiff / 365;
     let units = " years ago";
 
-    if (dayDiff == 0) {
+    if (dayDiff === 0) {
         [numericPart, units] = [secondDiff / 3600, " hours ago"];
 
         if (secondDiff < 10) {
@@ -26,7 +26,7 @@ const prettyTimeDifference = (difference) => {
         } else if (secondDiff < 7200) {
             [numericPart, units] = [null, "an hour ago"];
         }
-    } else if (dayDiff == 1) {
+    } else if (dayDiff === 1) {
         [numericPart, units] = [null, "yesterday"];
     } else if (dayDiff < 7) {
         [numericPart, units] = [dayDiff, " days ago"];


### PR DESCRIPTION
The linter had a lot of warnings when starting up the dev server. This
fixes all those warnings and makes sure we do things correctly

  - Array.map() was changed to Array.forEach() as it was only iterating and
not changing
  - Initial render call had explicit ignore added to clarify that it's a
  one-time render thing
  - Unused imports and functions removed
  - Incorrect usage of useState was fixed for columns (never needed
    state management for it)
  - checkValidProject was changed to be a callback and the useState
    using it was changed to correctly use it as a dependency

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

Note that #205 fixes some things for me, so until that is merged I cannot properly verify that the changes work as it should

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Fix ESLint warnings
RELEASE NOTES END
