### PR TITLE
feat: load indicator using React Query

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ transpile-prod:
 # if you change flask port for dev, also change it in frontend/package.json in the proxy key/value
 
 run-dev-frontend:
-	cd frontend && REACT_APP_API_URL=$(API_STG) yarn start
+	cd frontend && REACT_APP_API_URL=$(API_STG) GENERATE_SOURCEMAP=true HTTPS=true yarn start
 
 run-dev-flask:
 	FLASK_ENV=development FLASK_APP=packit_dashboard.app flask-3 run --host=0.0.0.0

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,6 +15,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-query": "^3.39.3",
     "react-router-dom": "^6.6.2",
     "react-scripts": "5.0.1",
     "resize-observer-polyfill": "^1.5.1",

--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -3,13 +3,18 @@ import "@patternfly/react-core/dist/styles/base.css";
 import { BrowserRouter as Router } from "react-router-dom";
 import { AppLayout } from "./components/app_layout";
 import { AppRoutes } from "./routes";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+const queryClient = new QueryClient();
 
 const App = () => {
     return (
         <Router>
-            <AppLayout>
-                <AppRoutes />
-            </AppLayout>
+            <QueryClientProvider client={queryClient}>
+                <AppLayout>
+                    <AppRoutes />
+                </AppLayout>
+            </QueryClientProvider>
         </Router>
     );
 };

--- a/frontend/src/components/forge_icon.js
+++ b/frontend/src/components/forge_icon.js
@@ -17,13 +17,13 @@ const ForgeIcon = (props) => {
             forgeIcon = <GitlabIcon />;
             break;
         default:
-            // patternfly doesnt have an icon for pagure
+            // patternfly doesn't have an icon for pagure
             forgeIcon = <GitIcon />;
             break;
     }
 
     return (
-        <Tooltip position="top" content={<span>{forge}</span>}>
+        <Tooltip position="top" content={forge} aria="labelledby">
             {forgeIcon}
         </Tooltip>
     );

--- a/frontend/src/components/tables/propose_downstream.js
+++ b/frontend/src/components/tables/propose_downstream.js
@@ -1,12 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useMemo } from "react";
 
 import {
     Table,
     TableHeader,
     TableBody,
     TableVariant,
-    sortable,
-    SortByDirection,
     cellWidth,
 } from "@patternfly/react-table";
 
@@ -17,6 +15,7 @@ import Preloader from "../preloader";
 import ForgeIcon from "../forge_icon";
 import { ProposeDownstreamTargetStatusLabel } from "../status_labels";
 import { Timestamp } from "../../utils/time";
+import { useInfiniteQuery } from "react-query";
 
 const ProposeDownstreamStatuses = (props) => {
     let labels = [];
@@ -40,35 +39,28 @@ const ProposeDownstreamStatuses = (props) => {
 const ProposeDownstreamsTable = () => {
     // Headings
     const columns = [
-        { title: "", transforms: [cellWidth(5)] }, // space for forge icon
+        {
+            title: <span className="pf-u-screen-reader">Forge</span>,
+            transforms: [cellWidth(5)],
+        }, // space for forge icon
         { title: "Trigger", transforms: [cellWidth(25)] },
         { title: "Targets", transforms: [cellWidth(60)] },
-        { title: "Time Submitted", transforms: [sortable, cellWidth(20)] },
+        { title: "Time Submitted", transforms: [cellWidth(20)] },
     ];
 
-    // Local State
-    const [rows, setRows] = useState([]);
-    const [hasError, setErrors] = useState(false);
-    const [loaded, setLoaded] = useState(false);
-    const [sortBy, setSortBy] = useState({});
-    const [page, setPage] = useState(1);
-
     // Fetch data from dashboard backend (or if we want, directly from the API)
-    function fetchData() {
+    const fetchData = ({ pageParam = 1 }) =>
         fetch(
-            `${process.env.REACT_APP_API_URL}/propose-downstream?page=${page}&per_page=20`
+            `${process.env.REACT_APP_API_URL}/propose-downstream?page=${pageParam}&per_page=20`
         )
             .then((response) => response.json())
-            .then((data) => {
-                jsonToRow(data);
-                setLoaded(true);
-                setPage(page + 1); // set next page
-            })
-            .catch((err) => {
-                console.log(err);
-                setErrors(err);
-            });
-    }
+            .then((data) => jsonToRow(data));
+
+    const { isLoading, isError, fetchNextPage, data, isFetching } =
+        useInfiniteQuery("propose-downstream", fetchData, {
+            getNextPageParam: (_, allPages) => allPages.length + 1,
+            keepPreviousData: true,
+        });
 
     // Convert fetched json into row format that the table can read
     function jsonToRow(res) {
@@ -112,53 +104,28 @@ const ProposeDownstreamsTable = () => {
             };
             rowsList.push(singleRow);
         });
-        setRows(rows.concat(rowsList));
+        return rowsList;
     }
 
-    function onSort(_event, index, direction) {
-        const sortedRows = rows.sort((a, b) =>
-            a[index] < b[index] ? -1 : a[index] > b[index] ? 1 : 0
-        );
-        setSortBy({
-            index,
-            direction,
-        });
-        setRows(
-            direction === SortByDirection.asc
-                ? sortedRows
-                : sortedRows.reverse()
-        );
-    }
-
-    // Load more items
-    function nextPage() {
-        fetchData();
-    }
-
-    // Executes fetchData on first render of component
-    // look at detailed comment in ./copr_builds_table.js
-    useEffect(() => {
-        fetchData();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    // Create a memoization of all the data when we flatten it out. Ideally one should render all the pages separately so that rendering will be done faster
+    const rows = useMemo(() => (data ? data.pages.flat() : []), [data]);
 
     // If backend API is down
-    if (hasError) {
+    if (isError) {
         return <ConnectionError />;
     }
 
     // Show preloader if waiting for API data
-    if (!loaded) {
+    // TODO(SpyTec): Replace with skeleton loader, we know the data will look like
+    if (isLoading) {
         return <Preloader />;
     }
 
     return (
         <div>
             <Table
-                aria-label="Sortable Table"
+                aria-label="Table of propose downstream runs"
                 variant={TableVariant.compact}
-                sortBy={sortBy}
-                onSort={onSort}
                 cells={columns}
                 rows={rows}
             >
@@ -167,8 +134,12 @@ const ProposeDownstreamsTable = () => {
             </Table>
             <center>
                 <br />
-                <Button variant="control" onClick={nextPage}>
-                    Load More
+                <Button
+                    variant="control"
+                    onClick={() => fetchNextPage()}
+                    isAriaDisabled={isFetching}
+                >
+                    {isFetching ? "Fetching data" : "Load more"}
                 </Button>
             </center>
         </div>

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1036,6 +1036,13 @@
   dependencies:
     regenerator-runtime "^0.13.11"
 
+"@babel/runtime@^7.5.5", "@babel/runtime@^7.6.2", "@babel/runtime@^7.7.2":
+  version "7.20.13"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.13.tgz#7055ab8a7cff2b8f6058bf6ae45ff84ad2aded4b"
+  integrity sha512-gt3PKXs0DBoL9xCvOIIZ2NEqAGZqHjAnmVbfQtB620V0uReIQutpel14KcneZuer7UioY8ALKZ7iocavvzTNFA==
+  dependencies:
+    regenerator-runtime "^0.13.11"
+
 "@babel/template@^7.18.10", "@babel/template@^7.20.7", "@babel/template@^7.3.3":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.20.7.tgz#a15090c2839a83b02aa996c0b4994005841fd5a8"
@@ -2861,6 +2868,11 @@ bfj@^7.0.2:
     hoopy "^0.1.4"
     tryer "^1.0.1"
 
+big-integer@^1.6.16:
+  version "1.6.51"
+  resolved "https://registry.yarnpkg.com/big-integer/-/big-integer-1.6.51.tgz#0df92a5d9880560d3ff2d5fd20245c889d130686"
+  integrity sha512-GPEid2Y9QU1Exl1rpO9B2IPJGHPSupF5GnVIP0blYvNOMer2bTvSWs1jGOUg04hTmu67nmLsQ9TBo1puaotBHg==
+
 big.js@^5.2.2:
   version "5.2.2"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-5.2.2.tgz#65f0af382f578bcdc742bd9c281e9cb2d7768328"
@@ -2930,6 +2942,20 @@ braces@^3.0.2, braces@~3.0.2:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+broadcast-channel@^3.4.1:
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/broadcast-channel/-/broadcast-channel-3.7.0.tgz#2dfa5c7b4289547ac3f6705f9c00af8723889937"
+  integrity sha512-cIAKJXAxGJceNZGTZSBzMxzyOn72cVgPnKx4dc6LRjQgbaJUQqhy5rzL3zbMxkMWsGKkv2hSFkPRMEXfoMZ2Mg==
+  dependencies:
+    "@babel/runtime" "^7.7.2"
+    detect-node "^2.1.0"
+    js-sha3 "0.8.0"
+    microseconds "0.2.0"
+    nano-time "1.0.0"
+    oblivious-set "1.0.0"
+    rimraf "3.0.2"
+    unload "2.2.0"
 
 browser-process-hrtime@^1.0.0:
   version "1.0.0"
@@ -3653,7 +3679,7 @@ detect-newline@^3.0.0:
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
 
-detect-node@^2.0.4:
+detect-node@^2.0.4, detect-node@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.1.0.tgz#c9c70775a49c3d03bc2c06d9a73be550f978f8b1"
   integrity sha512-T0NIuQpnTvFDATNuHN5roPwSBG83rFsuO+MXXH9/3N1eFbn4wcPjttvjMLEPWJ0RGUYgQE7cGgS3tNxbqCGM7g==
@@ -5928,6 +5954,11 @@ js-sdsl@^4.1.4:
   resolved "https://registry.yarnpkg.com/js-sdsl/-/js-sdsl-4.2.0.tgz#278e98b7bea589b8baaf048c20aeb19eb7ad09d0"
   integrity sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==
 
+js-sha3@0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/js-sha3/-/js-sha3-0.8.0.tgz#b9b7a5da73afad7dedd0f8c463954cbde6818840"
+  integrity sha512-gF1cRrHhIzNfToc802P800N8PpXS+evLLXfsVpowqmAFR9uwbi89WvXg2QspOmXL8QL86J4T1EpFu+yUkwJY3Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -6233,6 +6264,14 @@ makeerror@1.0.12:
   dependencies:
     tmpl "1.0.5"
 
+match-sorter@^6.0.2:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/match-sorter/-/match-sorter-6.3.1.tgz#98cc37fda756093424ddf3cbc62bfe9c75b92bda"
+  integrity sha512-mxybbo3pPNuA+ZuCUhm5bwNkXrJTbsk5VWbR5wiwz/GC6LIiegBGn2w3O08UG/jdbYLinw51fSQ5xNU1U3MgBw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+    remove-accents "0.4.2"
+
 mdn-data@2.0.14:
   version "2.0.14"
   resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.14.tgz#7113fc4281917d63ce29b43446f701e68c25ba50"
@@ -6287,6 +6326,11 @@ micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.5:
   dependencies:
     braces "^3.0.2"
     picomatch "^2.3.1"
+
+microseconds@0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/microseconds/-/microseconds-0.2.0.tgz#233b25f50c62a65d861f978a4a4f8ec18797dc39"
+  integrity sha512-n7DHHMjR1avBbSpsTBj6fmMGh2AGrifVV4e+WYc3Q9lO+xnSZ3NyhcBND3vzzatt05LFhoKFRxrIyklmLlUtyA==
 
 mime-db@1.52.0, "mime-db@>= 1.43.0 < 2":
   version "1.52.0"
@@ -6375,6 +6419,13 @@ multicast-dns@^7.2.5:
   dependencies:
     dns-packet "^5.2.2"
     thunky "^1.0.2"
+
+nano-time@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/nano-time/-/nano-time-1.0.0.tgz#b0554f69ad89e22d0907f7a12b0993a5d96137ef"
+  integrity sha512-flnngywOoQ0lLQOTRNexn2gGSNuM9bKj9RZAWSzhQ+UJYaAFG9bac4DW9VHjUAzrOaIcajHybCTHe/bkvozQqA==
+  dependencies:
+    big-integer "^1.6.16"
 
 nanoid@^3.3.4:
   version "3.3.4"
@@ -6547,6 +6598,11 @@ object.values@^1.1.0, object.values@^1.1.6:
     call-bind "^1.0.2"
     define-properties "^1.1.4"
     es-abstract "^1.20.4"
+
+oblivious-set@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/oblivious-set/-/oblivious-set-1.0.0.tgz#c8316f2c2fb6ff7b11b6158db3234c49f733c566"
+  integrity sha512-z+pI07qxo4c2CulUHCDf9lcqDlMSo72N/4rLUpRXf6fu+q8vjt8y0xS+Tlf8NTJDdTXHbdeO1n3MlbctwEoXZw==
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -7586,6 +7642,15 @@ react-is@^18.0.0:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-18.2.0.tgz#199431eeaaa2e09f86427efbb4f1473edb47609b"
   integrity sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==
 
+react-query@^3.39.3:
+  version "3.39.3"
+  resolved "https://registry.yarnpkg.com/react-query/-/react-query-3.39.3.tgz#4cea7127c6c26bdea2de5fb63e51044330b03f35"
+  integrity sha512-nLfLz7GiohKTJDuT4us4X3h/8unOh+00MLb2yJoGTPjxKs2bc1iDhkNx2bd5MKklXnOD3NrVZ+J2UXujA5In4g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    broadcast-channel "^3.4.1"
+    match-sorter "^6.0.2"
+
 react-refresh@^0.11.0:
   version "0.11.0"
   resolved "https://registry.yarnpkg.com/react-refresh/-/react-refresh-0.11.0.tgz#77198b944733f0f1f1a90e791de4541f9f074046"
@@ -7791,6 +7856,11 @@ relateurl@^0.2.7:
   resolved "https://registry.yarnpkg.com/relateurl/-/relateurl-0.2.7.tgz#54dbf377e51440aca90a4cd274600d3ff2d888a9"
   integrity sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog==
 
+remove-accents@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/remove-accents/-/remove-accents-0.4.2.tgz#0a43d3aaae1e80db919e07ae254b285d9e1c7bb5"
+  integrity sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA==
+
 renderkid@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/renderkid/-/renderkid-3.0.0.tgz#5fd823e4d6951d37358ecc9a58b1f06836b6268a"
@@ -7883,7 +7953,7 @@ reusify@^1.0.4:
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.0.4.tgz#90da382b1e126efc02146e90845a88db12925d76"
   integrity sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
 
-rimraf@^3.0.0, rimraf@^3.0.2:
+rimraf@3.0.2, rimraf@^3.0.0, rimraf@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
@@ -8787,6 +8857,14 @@ universalify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
   integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+
+unload@2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/unload/-/unload-2.2.0.tgz#ccc88fdcad345faa06a92039ec0f80b488880ef7"
+  integrity sha512-B60uB5TNBLtN6/LsgAf3udH9saB5p7gqJwcFfbOEZ8BcBHnGwCf6G/TGiEqkRAxX7zAFIUtzdrXQSdL3Q/wqNA==
+  dependencies:
+    "@babel/runtime" "^7.6.2"
+    detect-node "^2.0.4"
 
 unpipe@1.0.0, unpipe@~1.0.0:
   version "1.0.0"


### PR DESCRIPTION
This starts using React Query for utilizing requests to the Packit API.
If the user is on a page and alt tabs currently or is inactive for a
while the page will refresh the content automatically as well. This can
be disabled either for each query individually or modified globally.

With React Query we also use caching to a better extent if it is ever
needed.

When the demo loads pages 1 through 3 it is due to alt tabbing to showcase the refresh of pages

TODO:

- [x] Other tabs in jobs page
- [x] Approval on introducing React Query dependency

<!-- notes for reviewers -->

https://user-images.githubusercontent.com/6598829/216692107-8fb0c5ca-000c-41f2-8ee9-84a052a65dd8.mp4



<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #212 #211 #210

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Improve fetching of API content in paginated tables
RELEASE NOTES END
