### PR TITLE
Refactor React Router usage

### DIFF
--- a/frontend/src/app.js
+++ b/frontend/src/app.js
@@ -1,21 +1,17 @@
 import React from "react";
 import "@patternfly/react-core/dist/styles/base.css";
-import { BrowserRouter as Router } from "react-router-dom";
-import { AppLayout } from "./components/app_layout";
-import { AppRoutes } from "./routes";
+import { RouterProvider, createBrowserRouter } from "react-router-dom";
+import { routes } from "./routes";
 import { QueryClient, QueryClientProvider } from "react-query";
 
 const queryClient = new QueryClient();
+const router = createBrowserRouter(routes);
 
 const App = () => {
     return (
-        <Router>
-            <QueryClientProvider client={queryClient}>
-                <AppLayout>
-                    <AppRoutes />
-                </AppLayout>
-            </QueryClientProvider>
-        </Router>
+        <QueryClientProvider client={queryClient}>
+            <RouterProvider router={router} />
+        </QueryClientProvider>
     );
 };
 export default App;

--- a/frontend/src/components/app_layout.js
+++ b/frontend/src/components/app_layout.js
@@ -1,5 +1,4 @@
-import * as React from "react";
-import { NavLink } from "react-router-dom";
+import { NavLink, Outlet, matchRoutes, useLocation } from "react-router-dom";
 import {
     Brand,
     Nav,
@@ -12,14 +11,33 @@ import {
 } from "@patternfly/react-core";
 import { routes } from "../routes";
 import packitLogo from "../static/logo.png";
+import { useState, useEffect } from "react";
 
-const AppLayout = ({ children }) => {
+const AppLayout = () => {
+    const location = useLocation();
+    const [activeLocationLabel, setActiveLocationLabel] = useState("");
+    const currentRouteTree = matchRoutes(routes, location);
+    // Dynamically set page title and update currently active page in sidebar
+    useEffect(() => {
+        // it matches everything that has to do with the current URL. Start from the leaf and work up to set title if at all.
+        for (let index = currentRouteTree.length - 1; index >= 0; index--) {
+            const element = currentRouteTree[index];
+            if (element.route.label) {
+                setActiveLocationLabel(element.route.label);
+            }
+            if (element.route?.title) {
+                document.title = element.route.title;
+                break;
+            }
+        }
+    }, [currentRouteTree]);
+
     const logoProps = {
         href: "/",
     };
-    const [isNavOpen, setIsNavOpen] = React.useState(true);
-    const [isMobileView, setIsMobileView] = React.useState(true);
-    const [isNavOpenMobile, setIsNavOpenMobile] = React.useState(false);
+    const [isNavOpen, setIsNavOpen] = useState(true);
+    const [isMobileView, setIsMobileView] = useState(true);
+    const [isNavOpenMobile, setIsNavOpenMobile] = useState(false);
     const onNavToggleMobile = () => {
         setIsNavOpenMobile(!isNavOpenMobile);
     };
@@ -38,24 +56,17 @@ const AppLayout = ({ children }) => {
             onNavToggle={isMobileView ? onNavToggleMobile : onNavToggle}
         />
     );
-
     const Navigation = (
         <Nav id="nav-primary-simple" theme="dark">
             <NavList id="nav-list-simple">
-                {routes.map(
-                    (route, idx) =>
+                {routes[0].children.map(
+                    (route, index) =>
                         route.label && (
                             <NavItem
-                                key={`${route.label}-${idx}`}
-                                id={`${route.label}-${idx}`}
+                                key={route.label}
+                                isActive={activeLocationLabel === route.label}
                             >
-                                <NavLink
-                                    exact="true"
-                                    to={route.path}
-                                    className={({ isActive }) =>
-                                        isActive ? "pf-m-current" : ""
-                                    }
-                                >
+                                <NavLink itemID={index} to={route.path}>
                                     {route.label}
                                 </NavLink>
                             </NavItem>
@@ -99,7 +110,7 @@ const AppLayout = ({ children }) => {
             onPageResize={onPageResize}
             skipToContent={PageSkipToContent}
         >
-            {children}
+            <Outlet />
         </Page>
     );
 };

--- a/frontend/src/components/jobs.js
+++ b/frontend/src/components/jobs.js
@@ -25,7 +25,7 @@ const Jobs = () => {
     const jobRoutes = currentRouteTree.find((r) => r.pathname === JOBS_ROUTE)
         .route.children;
     const activeJobRoute = currentRouteTree.find((r) =>
-        r.pathname.includes(JOBS_ROUTE + "/")
+        r.pathname.includes(JOBS_ROUTE + "/"),
     );
 
     // if we're not inside a specific route, default to copr-builds and redirect

--- a/frontend/src/components/jobs.js
+++ b/frontend/src/components/jobs.js
@@ -1,84 +1,72 @@
-import * as React from "react";
 import {
+    Nav,
+    NavItem,
+    NavList,
+    PageGroup,
+    PageNavigation,
     PageSection,
     PageSectionVariants,
-    Tabs,
-    Tab,
-    TabTitleText,
-    TextContent,
-    Card,
-    CardBody,
     Text,
+    TextContent,
 } from "@patternfly/react-core";
-import TestingFarmResultsTable from "./tables/testing_farm";
-import CoprBuildsTable from "./tables/copr";
-import KojiBuildsTable from "./tables/koji";
-import SRPMBuildsTable from "./tables/srpm";
-import ProposeDownstreamTable from "./tables/propose_downstream";
-
+import { useEffect } from "react";
+import {
+    matchRoutes,
+    NavLink,
+    Outlet,
+    useLocation,
+    useNavigate,
+} from "react-router-dom";
+import { routes } from "../routes";
+const JOBS_ROUTE = "/jobs";
 const Jobs = () => {
-    const [activeTabKey, setActiveTabKey] = React.useState(0);
-    const handleTabClick = (event, tabIndex) => {
-        setActiveTabKey(tabIndex);
-    };
+    const location = useLocation();
+    const currentRouteTree = matchRoutes(routes, location);
+    const jobRoutes = currentRouteTree.find((r) => r.pathname === JOBS_ROUTE)
+        .route.children;
+    const activeJobRoute = currentRouteTree.find((r) =>
+        r.pathname.includes(JOBS_ROUTE + "/")
+    );
+
+    // if we're not inside a specific route, default to copr-builds and redirect
+    const navigate = useNavigate();
+    useEffect(() => {
+        if (!activeJobRoute) {
+            navigate("/jobs/copr-builds");
+        }
+    }, [activeJobRoute, navigate]);
+
     return (
-        <div>
+        <PageGroup>
             <PageSection variant={PageSectionVariants.light}>
                 <TextContent>
                     <Text component="h1">Jobs</Text>
                     <Text component="p">List of jobs by Packit Service</Text>
                 </TextContent>
             </PageSection>
-
             <PageSection>
-                <Card>
-                    <CardBody>
-                        <Tabs
-                            isFilled
-                            mountOnEnter
-                            activeKey={activeTabKey}
-                            onSelect={handleTabClick}
-                            isBox={true}
-                        >
-                            <Tab
-                                eventKey={0}
-                                title={<TabTitleText>Copr Builds</TabTitleText>}
-                            >
-                                <CoprBuildsTable />
-                            </Tab>
-                            <Tab
-                                eventKey={1}
-                                title={<TabTitleText>Koji Builds</TabTitleText>}
-                            >
-                                <KojiBuildsTable />
-                            </Tab>
-                            <Tab
-                                eventKey={2}
-                                title={<TabTitleText>SRPM Builds</TabTitleText>}
-                            >
-                                <SRPMBuildsTable />
-                            </Tab>
-                            <Tab
-                                eventKey={3}
-                                title={<TabTitleText>Test Runs</TabTitleText>}
-                            >
-                                <TestingFarmResultsTable />
-                            </Tab>
-                            <Tab
-                                eventKey={4}
-                                title={
-                                    <TabTitleText>
-                                        Propose Downstreams
-                                    </TabTitleText>
-                                }
-                            >
-                                <ProposeDownstreamTable />
-                            </Tab>
-                        </Tabs>
-                    </CardBody>
-                </Card>
+                <PageNavigation>
+                    <Nav aria-label="Job types" variant="tertiary">
+                        <NavList>
+                            {jobRoutes.map((route) => (
+                                <NavItem
+                                    key={route.path}
+                                    isActive={
+                                        route.path ===
+                                        activeJobRoute?.route.path
+                                    }
+                                >
+                                    <NavLink to={"/jobs/" + route.path}>
+                                        {route.label}
+                                    </NavLink>
+                                </NavItem>
+                            ))}
+                        </NavList>
+                    </Nav>
+                </PageNavigation>
+                <Outlet />
             </PageSection>
-        </div>
+        </PageGroup>
     );
 };
 

--- a/frontend/src/components/project_info.js
+++ b/frontend/src/components/project_info.js
@@ -156,11 +156,14 @@ const ProjectInfo = () => {
 };
 
 const ProjectLink = (props) => {
-    const handleClick = () => window.open(props.link, "_blank");
     if (props.link === "") {
-        return "";
+        return <></>;
     }
-    return <ExternalLinkAltIcon onClick={handleClick} />;
+    return (
+        <a href={props.link} target="_blank" rel="noreferrer">
+            <ExternalLinkAltIcon />
+        </a>
+    );
 };
 
 export { ProjectInfo };

--- a/frontend/src/components/status_labels.js
+++ b/frontend/src/components/status_labels.js
@@ -9,6 +9,7 @@ import {
     InfoCircleIcon,
     RedoIcon,
 } from "@patternfly/react-icons";
+import { Link } from "react-router-dom";
 
 /**
  * Represents an internal base class for status labels. Handles rendering and basic
@@ -29,6 +30,7 @@ class BaseStatusLabel extends React.Component {
     constructor(props) {
         super(props);
         this.link = props.link;
+        this.isExternalLink = props.link.startsWith("http");
         this.tooltipText = props.status;
     }
 
@@ -36,7 +38,30 @@ class BaseStatusLabel extends React.Component {
         return (
             <Tooltip content={this.tooltipText}>
                 <span style={{ padding: "2px" }}>
-                    <Label icon={this.icon} color={this.color} href={this.link}>
+                    <Label
+                        icon={this.icon}
+                        color={this.color}
+                        render={({ className, content, componentRef }) => {
+                            return this.isExternalLink ? (
+                                <a
+                                    href={this.link}
+                                    className={className}
+                                    target="_blank"
+                                    rel="noreferrer"
+                                >
+                                    {content}
+                                </a>
+                            ) : (
+                                <Link
+                                    to={this.link}
+                                    className={className}
+                                    innerRef={componentRef}
+                                >
+                                    {content}
+                                </Link>
+                            );
+                        }}
+                    >
                         {this.label}
                         <span className="pf-u-screen-reader">
                             {this.tooltipText}

--- a/frontend/src/components/tables/pipelines.js
+++ b/frontend/src/components/tables/pipelines.js
@@ -30,16 +30,17 @@ class Statuses extends React.Component {
         this.name = props.name;
 
         this.labels = [];
-        for (let entry of props.entries) {
+        props.entries.forEach((entry, i) => {
             this.labels.push(
                 <props.statusClass
+                    key={i}
                     status={entry.status}
                     chroot={entry.target}
                     target={entry.target}
-                    link={`results/${props.route}/${entry.packit_id}`}
+                    link={`/results/${props.route}/${entry.packit_id}`}
                 />,
             );
-        }
+        });
     }
 
     render() {

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -1,20 +1,25 @@
 import * as React from "react";
 import { Route, Routes } from "react-router-dom";
 
+import { AppLayout } from "./components/app_layout";
 import { Dashboard } from "./components/dashboard";
+import { Forge } from "./components/forge";
 import { Jobs } from "./components/jobs";
-import { Projects } from "./components/projects";
 import { Namespace } from "./components/namespace";
-import { ProjectInfo } from "./components/project_info";
 import { NotFound } from "./components/not_found";
-import { ResultsPageSRPM } from "./components/results/srpm";
+import Pipelines from "./components/pipelines";
+import { Projects } from "./components/projects";
+import { ProjectInfo } from "./components/project_info";
 import { ResultsPageCopr } from "./components/results/copr";
 import { ResultsPageKoji } from "./components/results/koji";
-import { ResultsPageTestingFarm } from "./components/results/testing_farm";
 import { ResultsPageProposeDownstream } from "./components/results/propose_downstream";
-import { Forge } from "./components/forge";
-import Pipelines from "./components/pipelines";
-import { AppLayout } from "./components/app_layout";
+import { ResultsPageSRPM } from "./components/results/srpm";
+import { ResultsPageTestingFarm } from "./components/results/testing_farm";
+import CoprBuildsTable from "./components/tables/copr";
+import KojiBuildsTable from "./components/tables/koji";
+import ProposeDownstreamTable from "./components/tables/propose_downstream";
+import SRPMBuildsTable from "./components/tables/srpm";
+import TestingFarmResultsTable from "./components/tables/testing_farm";
 
 // Main Menu routes
 const routes = [
@@ -35,6 +40,34 @@ const routes = [
                 label: "Jobs",
                 path: "/jobs",
                 title: "Jobs | Packit Service",
+                children: [
+                    {
+                        element: <CoprBuildsTable />,
+                        index: true,
+                        label: "Copr Builds",
+                        path: "copr-builds",
+                    },
+                    {
+                        element: <KojiBuildsTable />,
+                        label: "Koji Builds",
+                        path: "koji-builds",
+                    },
+                    {
+                        element: <SRPMBuildsTable />,
+                        label: "SRPM Builds",
+                        path: "srpm-builds",
+                    },
+                    {
+                        element: <TestingFarmResultsTable />,
+                        label: "Testing Farm Runs",
+                        path: "testing-farm-runs",
+                    },
+                    {
+                        element: <ProposeDownstreamTable />,
+                        label: "Propose Downstreams",
+                        path: "propose-downstreams",
+                    },
+                ],
             },
             {
                 element: <Pipelines />,

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -14,36 +14,81 @@ import { ResultsPageTestingFarm } from "./components/results/testing_farm";
 import { ResultsPageProposeDownstream } from "./components/results/propose_downstream";
 import { Forge } from "./components/forge";
 import Pipelines from "./components/pipelines";
+import { AppLayout } from "./components/app_layout";
 
 // Main Menu routes
 const routes = [
     {
-        element: <Dashboard />,
-        exact: true,
+        element: <AppLayout />,
         label: "Home",
         path: "/",
-        title: "Home | Packit Service",
-    },
-    {
-        element: <Jobs />,
-        exact: true,
-        label: "Jobs",
-        path: "/jobs",
-        title: "Jobs | Packit Service",
-    },
-    {
-        element: <Pipelines />,
-        exact: true,
-        label: "Pipelines",
-        path: "/pipelines",
-        title: "Pipelines | Packit Service",
-    },
-    {
-        element: <Projects />,
-        exact: true,
-        label: "Projects",
-        path: "/projects",
-        title: "Projects | Packit Service",
+        title: "Packit Service",
+        children: [
+            {
+                element: <Dashboard />,
+                index: true,
+                label: "Home",
+                path: "/",
+            },
+            {
+                element: <Jobs />,
+                label: "Jobs",
+                path: "/jobs",
+                title: "Jobs | Packit Service",
+            },
+            {
+                element: <Pipelines />,
+                label: "Pipelines",
+                path: "/pipelines",
+                title: "Pipelines | Packit Service",
+            },
+            {
+                element: <Projects />,
+                label: "Projects",
+                path: "/projects",
+                title: "Projects | Packit Service",
+            },
+            {
+                path: "/projects/:forge/",
+                element: <Forge />,
+                title: "Project Forge | Packit Service",
+            },
+            {
+                path: "/projects/:forge/:namespace",
+                element: <Namespace />,
+                title: "Project Namespace | Packit Service",
+            },
+            {
+                path: "/projects/:forge/:namespace/:repoName",
+                element: <ProjectInfo />,
+                title: "Project | Packit Service",
+            },
+            {
+                path: "/results/srpm-builds/:id",
+                element: <ResultsPageSRPM />,
+                title: "SRPM Results | Packit Service",
+            },
+            {
+                path: "/results/copr-builds/:id",
+                element: <ResultsPageCopr />,
+                title: "Copr Results | Packit Service",
+            },
+            {
+                path: "/results/koji-builds/:id",
+                element: <ResultsPageKoji />,
+                title: "Koji Results | Packit Service",
+            },
+            {
+                path: "/results/testing-farm/:id",
+                element: <ResultsPageTestingFarm />,
+                title: "Testing Farm Results | Packit Service",
+            },
+            {
+                path: "/results/propose-downstream/:id",
+                element: <ResultsPageProposeDownstream />,
+                title: "Propose Results | Packit Service",
+            },
+        ],
     },
 ];
 


### PR DESCRIPTION
This fixes a bunch of different things. Specifically the issues I opened today

Most of the links within the site now default to using React Router Link or NavLink where appropriate, preventing any page reload. Fixes #221

There is now a way to see current page on the sidebar if you are on pipelines or jobs page for instance. Fixes #222

Jobs tables have been updated to allow linking to specific tables. I also took the liberty of refactoring the website route structure to now fully utilize Outlet instead of rendering components wherever needed and having to deal with other issues like the tables would have been. Fixes #223

TODO:

- [ ] Going to a page that is not in the sidebar will not make sidebar change the style of isActive, meaning that if you go to a results page it will still show that the last page is active in the sidebar

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Refactor React Router to use Outlet for routes
Add links for job tables
RELEASE NOTES END
