### PR TITLE
feat: add commit hash in page header

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -39,6 +39,7 @@ jobs:
           unique_tag="${branch}-${GITHUB_SHA::7}"
           echo "tag=${tag} ${unique_tag}" >> $GITHUB_OUTPUT
           echo "api=${api}" >> $GITHUB_OUTPUT
+          echo "commit_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
         id: branch_tag
 
       - name: Build Image
@@ -49,7 +50,7 @@ jobs:
           dockerfiles: ${{ matrix.dockerfile }}
           image: ${{ matrix.image }}
           tags: ${{ steps.branch_tag.outputs.tag }}
-          build-args: REACT_APP_API_URL=${{ steps.branch_tag.outputs.api }}
+          build-args: REACT_APP_API_URL=${{ steps.branch_tag.outputs.api }} REACT_APP_GIT_SHA=${{ steps.branch_tag.outputs.commit_sha }}
           oci: true
 
       - name: Push To Quay

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM quay.io/packit/base
 ARG REACT_APP_API_URL=https://stg.packit.dev/api
 ENV REACT_APP_API_URL ${REACT_APP_API_URL}
 
+ARG REACT_APP_GIT_SHA=dev
+ENV REACT_APP_GIT_SHA ${REACT_APP_GIT_SHA}
+
 ENV HOME=/home/packit_dashboard
 
 WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ run-container-stg: build-stg
 build-stg:
 	$(CONTAINER_ENGINE) build --rm \
 		--build-arg REASCT_APP_API_URL=$(API_STG) \
-		--build-arg GIT_SHA=$(GIT_SHA) \
+		--build-arg REACT_APP_GIT_SHA=$(GIT_SHA) \
 		-t $(IMAGE) -f Dockerfile .
 
 push-stg: build-stg

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -28,6 +28,7 @@
 
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="description" content="Dashboard for Packit Service." />
+    <meta name="ui-version" content="%REACT_APP_GIT_SHA%" />
     <style>
       html,
       body,

--- a/frontend/src/app/AppLayout/AppLayout.js
+++ b/frontend/src/app/AppLayout/AppLayout.js
@@ -5,13 +5,16 @@ import {
     NavList,
     NavItem,
     Page,
+    PageHeaderTools,
     PageHeader,
     PageSidebar,
+    Button,
     SkipToContent,
 } from "@patternfly/react-core";
 import { routes } from "../routes";
 import packitLogo from "../../static/logo.png";
 import { useState, useEffect } from "react";
+import { ExternalLinkSquareAltIcon } from "@patternfly/react-icons";
 
 const AppLayout = () => {
     const location = useLocation();
@@ -47,6 +50,23 @@ const AppLayout = () => {
     const onPageResize = (props) => {
         setIsMobileView(props.mobileView);
     };
+
+    const HeaderTools = (
+        <PageHeaderTools>
+            <Button
+                component="a"
+                href={`https://github.com/packit/dashboard/commit/${process.env.REACT_APP_GIT_SHA}`}
+                target="_blank"
+                rel="noreferrer"
+                variant="link"
+                icon={<ExternalLinkSquareAltIcon />}
+                iconPosition="right"
+                aria-label="External link to page source commit"
+            >
+                {process.env.REACT_APP_GIT_SHA.substring(0, 7)}
+            </Button>
+        </PageHeaderTools>
+    );
     const Header = (
         <PageHeader
             logo={<Brand src={packitLogo} alt="Packit Logo" />}
@@ -54,6 +74,7 @@ const AppLayout = () => {
             showNavToggle
             isNavOpen={isNavOpen}
             onNavToggle={isMobileView ? onNavToggleMobile : onNavToggle}
+            headerTools={HeaderTools}
         />
     );
     const Navigation = (


### PR DESCRIPTION
Within the header there will now be a shorthash visible that links to packit/dashboard page

Part of #209

![image](https://user-images.githubusercontent.com/6598829/222906597-57a21fed-6ca4-4e35-a430-fdc8fef07ebc.png)


TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Add commit hash for dashboard in page header
RELEASE NOTES END
