### PR TITLE
Set link for the SRPM results status label

### DIFF
--- a/frontend/src/components/results/srpm.js
+++ b/frontend/src/components/results/srpm.js
@@ -135,7 +135,10 @@ const ResultsPageSRPM = () => {
             <PageSection variant={PageSectionVariants.light}>
                 <TextContent>
                     <Text component="h1">SRPM Build</Text>
-                    <StatusLabel status={data.status} />
+                    <StatusLabel
+                        status={data.status}
+                        link={data.copr_web_url}
+                    />
                     <Text component="p">
                         <strong>
                             <TriggerLink builds={data} />


### PR DESCRIPTION
The link is required for the StatusLabel. Use the Copr web URL (we do the same for Copr build results).

Fixes #229


---

RELEASE NOTES BEGIN
￼
RELEASE NOTES END
