### PR TITLE
Allow null link in StatusLabel

### DIFF
--- a/frontend/src/components/status_labels.js
+++ b/frontend/src/components/status_labels.js
@@ -25,12 +25,12 @@ class BaseStatusLabel extends React.Component {
      * Constructs basic status label. Tooltip text defaults to status.
      *
      * @param {*} props Properties of the status label, minimal requirements are:
-     *  link and status.
+     *  status.
      */
     constructor(props) {
         super(props);
         this.link = props.link;
-        this.isExternalLink = props.link.startsWith("http");
+        this.isExternalLink = props.link && props.link.startsWith("http");
         this.tooltipText = props.status;
     }
 


### PR DESCRIPTION
In some situations, the StatusLabel is initialized with a null link ( e.g. when the propose-downstream fails, the link should point to the downstream PR, but there is no), which could previously lead to rendering errors.

Related to #229 

---

RELEASE NOTES BEGIN
￼
RELEASE NOTES END
