### PR TITLE
feat: Catch app crashes

### DIFF
--- a/frontend/src/components/branch.js
+++ b/frontend/src/components/branch.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 
-import ConnectionError from "./error";
+import ConnectionError from "./error_connection";
 import Preloader from "./preloader";
 import TriggerInfo from "./trigger_info";
 

--- a/frontend/src/components/error_app.js
+++ b/frontend/src/components/error_app.js
@@ -1,0 +1,87 @@
+import {
+    Button,
+    ClipboardCopyButton,
+    CodeBlock,
+    CodeBlockAction,
+    CodeBlockCode,
+    EmptyState,
+    EmptyStateBody,
+    EmptyStateIcon,
+    EmptyStateSecondaryActions,
+    Title,
+} from "@patternfly/react-core";
+import React from "react";
+
+import { ExclamationCircleIcon } from "@patternfly/react-icons";
+import { useRouteError } from "react-router-dom";
+
+const AppError = () => {
+    const error = useRouteError();
+    console.error(error);
+    const [copied, setCopied] = React.useState(false);
+
+    const clipboardCopyFunc = (event, text) => {
+        navigator.clipboard.writeText(text.toString());
+    };
+
+    const onClick = (event, text) => {
+        clipboardCopyFunc(event, text);
+        setCopied(true);
+    };
+
+    const actions = (
+        <CodeBlockAction>
+            <ClipboardCopyButton
+                id="basic-copy-button"
+                textId="code-content"
+                aria-label="Copy to clipboard"
+                onClick={(e) => onClick(e, error)}
+                exitDelay={copied ? 1500 : 600}
+                maxWidth="110px"
+                variant="plain"
+                onTooltipHidden={() => setCopied(false)}
+            >
+                {copied
+                    ? "Successfully copied to clipboard!"
+                    : "Copy to clipboard"}
+            </ClipboardCopyButton>
+        </CodeBlockAction>
+    );
+
+    return (
+        <EmptyState isFullHeight>
+            <EmptyStateIcon icon={ExclamationCircleIcon} color="#C9190B" />
+            <Title headingLevel="h1" size="lg">
+                Exception occured that caused the website to crash
+            </Title>
+            <EmptyStateBody>
+                If possible, take this callstack and report it upstream so it
+                can be fixed. When reporting, specify the reproducer on how the
+                bug happened.
+            </EmptyStateBody>
+            <Button
+                variant="primary"
+                component="a"
+                href="https://github.com/packit/dashboard/issues/new?title=Dashboard+crashed"
+                target="_blank"
+                rel="noreferrer"
+            >
+                Report the issue
+            </Button>
+            <EmptyStateSecondaryActions>
+                <Button variant="link" component="a" href="/">
+                    Go back to Packit website
+                </Button>
+            </EmptyStateSecondaryActions>
+            <EmptyStateBody>
+                <CodeBlock actions={actions}>
+                    <CodeBlockCode id="code-content">
+                        {error.toString()}
+                    </CodeBlockCode>
+                </CodeBlock>
+            </EmptyStateBody>
+        </EmptyState>
+    );
+};
+
+export default AppError;

--- a/frontend/src/components/error_connection.js
+++ b/frontend/src/components/error_connection.js
@@ -5,13 +5,16 @@ import {
     EmptyStateVariant,
     EmptyStateBody,
     Title,
+    Icon,
 } from "@patternfly/react-core";
 
-import { ExclamationCircleIcon } from "@patternfly/react-icons";
+import { ExclamationTriangleIcon } from "@patternfly/react-icons";
 
 const ConnectionError = () => (
     <EmptyState variant={EmptyStateVariant.small}>
-        <EmptyStateIcon icon={ExclamationCircleIcon} color="#C9190B" />
+        <Icon>
+            <EmptyStateIcon icon={ExclamationTriangleIcon} color="#f0ab00" />
+        </Icon>
         <Title headingLevel="h2" size="lg">
             Unable to connect
         </Title>

--- a/frontend/src/components/issues.js
+++ b/frontend/src/components/issues.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 
-import ConnectionError from "./error";
+import ConnectionError from "./error_connection";
 import Preloader from "./preloader";
 
 import { List, ListItem } from "@patternfly/react-core";

--- a/frontend/src/components/pr.js
+++ b/frontend/src/components/pr.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 
-import ConnectionError from "./error";
+import ConnectionError from "./error_connection";
 import Preloader from "./preloader";
 import TriggerInfo from "./trigger_info";
 

--- a/frontend/src/components/project_info.js
+++ b/frontend/src/components/project_info.js
@@ -17,7 +17,7 @@ import PullRequestList from "./pr";
 import BranchList from "./branch";
 import IssuesList from "./issues";
 import ReleasesList from "./releases";
-import ConnectionError from "./error";
+import ConnectionError from "./error_connection";
 import Preloader from "./preloader";
 import ForgeIcon from "./forge_icon";
 

--- a/frontend/src/components/projects_list.js
+++ b/frontend/src/components/projects_list.js
@@ -20,7 +20,7 @@ import {
     ExternalLinkAltIcon,
 } from "@patternfly/react-icons";
 
-import ConnectionError from "./error";
+import ConnectionError from "./error_connection";
 import Preloader from "./preloader";
 import { Link } from "react-router-dom";
 

--- a/frontend/src/components/releases.js
+++ b/frontend/src/components/releases.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 
-import ConnectionError from "./error";
+import ConnectionError from "./error_connection";
 import Preloader from "./preloader";
 
 const ReleasesList = (props) => {

--- a/frontend/src/components/results/copr.js
+++ b/frontend/src/components/results/copr.js
@@ -9,7 +9,7 @@ import {
     Title,
 } from "@patternfly/react-core";
 
-import ConnectionError from "../error";
+import ConnectionError from "../error_connection";
 import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { StatusLabel } from "../status_labels";

--- a/frontend/src/components/results/koji.js
+++ b/frontend/src/components/results/koji.js
@@ -9,7 +9,7 @@ import {
     Title,
 } from "@patternfly/react-core";
 
-import ConnectionError from "../error";
+import ConnectionError from "../error_connection";
 import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { StatusLabel } from "../status_labels";

--- a/frontend/src/components/results/srpm.js
+++ b/frontend/src/components/results/srpm.js
@@ -13,7 +13,7 @@ import {
 } from "@patternfly/react-core";
 import { LogViewer, LogViewerSearch } from "@patternfly/react-log-viewer";
 
-import ConnectionError from "../error";
+import ConnectionError from "../error_connection";
 import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { StatusLabel } from "../status_labels";

--- a/frontend/src/components/results/sync_release.js
+++ b/frontend/src/components/results/sync_release.js
@@ -12,7 +12,7 @@ import {
     ToolbarItem,
 } from "@patternfly/react-core";
 
-import ConnectionError from "../error";
+import ConnectionError from "../error_connection";
 import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { SyncReleaseTargetStatusLabel } from "../status_labels";

--- a/frontend/src/components/results/testing_farm.js
+++ b/frontend/src/components/results/testing_farm.js
@@ -10,7 +10,7 @@ import {
     Label,
 } from "@patternfly/react-core";
 
-import ConnectionError from "../error";
+import ConnectionError from "../error_connection";
 import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import { TFStatusLabel } from "../status_labels";

--- a/frontend/src/components/tables/copr.js
+++ b/frontend/src/components/tables/copr.js
@@ -10,7 +10,7 @@ import {
 
 import { Button } from "@patternfly/react-core";
 import TriggerLink from "../trigger_link";
-import ConnectionError from "../error";
+import ConnectionError from "../error_connection";
 import Preloader from "../preloader";
 import ForgeIcon from "../forge_icon";
 import { StatusLabel } from "../status_labels";

--- a/frontend/src/components/tables/koji.js
+++ b/frontend/src/components/tables/koji.js
@@ -10,7 +10,7 @@ import {
 
 import { Button } from "@patternfly/react-core";
 import TriggerLink from "../trigger_link";
-import ConnectionError from "../error";
+import ConnectionError from "../error_connection";
 import Preloader from "../preloader";
 import ForgeIcon from "../forge_icon";
 import { StatusLabel } from "../status_labels";

--- a/frontend/src/components/tables/pipelines.js
+++ b/frontend/src/components/tables/pipelines.js
@@ -10,7 +10,7 @@ import {
 
 import { Button, LabelGroup } from "@patternfly/react-core";
 import TriggerLink from "../trigger_link";
-import ConnectionError from "../error";
+import ConnectionError from "../error_connection";
 import Preloader from "../preloader";
 import ForgeIcon from "../forge_icon";
 import {

--- a/frontend/src/components/tables/srpm.js
+++ b/frontend/src/components/tables/srpm.js
@@ -10,7 +10,7 @@ import {
 
 import { Button } from "@patternfly/react-core";
 
-import ConnectionError from "../error";
+import ConnectionError from "../error_connection";
 import TriggerLink from "../trigger_link";
 import Preloader from "../preloader";
 import ForgeIcon from "../forge_icon";

--- a/frontend/src/components/tables/sync_release.js
+++ b/frontend/src/components/tables/sync_release.js
@@ -10,7 +10,7 @@ import {
 
 import { Button } from "@patternfly/react-core";
 import TriggerLink from "../trigger_link";
-import ConnectionError from "../error";
+import ConnectionError from "../error_connection";
 import Preloader from "../preloader";
 import ForgeIcon from "../forge_icon";
 import { SyncReleaseTargetStatusLabel } from "../status_labels";

--- a/frontend/src/components/tables/testing_farm.js
+++ b/frontend/src/components/tables/testing_farm.js
@@ -10,7 +10,7 @@ import {
 
 import { Button } from "@patternfly/react-core";
 
-import ConnectionError from "../error";
+import ConnectionError from "../error_connection";
 import Preloader from "../preloader";
 import TriggerLink from "../trigger_link";
 import ForgeIcon from "../forge_icon";

--- a/frontend/src/components/tables/usage.js
+++ b/frontend/src/components/tables/usage.js
@@ -8,7 +8,7 @@ import {
 } from "@patternfly/react-core";
 import { ChartDonut } from "@patternfly/react-charts";
 
-import ConnectionError from "../error";
+import ConnectionError from "../error_connection";
 import Preloader from "../preloader";
 import { useQuery } from "react-query";
 

--- a/frontend/src/routes.js
+++ b/frontend/src/routes.js
@@ -21,6 +21,7 @@ import SyncReleaseTable from "./components/tables/sync_release";
 import SRPMBuildsTable from "./components/tables/srpm";
 import TestingFarmResultsTable from "./components/tables/testing_farm";
 import Usage from "./components/usage";
+import AppError from "./components/error_app";
 
 // Main Menu routes
 const routes = [
@@ -29,6 +30,7 @@ const routes = [
         label: "Home",
         path: "/",
         title: "Packit Service",
+        errorElement: <AppError />,
         children: [
             {
                 element: <Dashboard />,


### PR DESCRIPTION
If the app crashes we casn now have a error element that can display to the user. This will display a log of what happened, and also let the user know they can report it upstream and also go back to the main page.

First commit shows the feature
Second commit shows refactor of existing connection error 

App crash exception
![image](https://user-images.githubusercontent.com/6598829/223881109-e0e437ff-cff3-4eb1-8f53-18ccb1a126b7.png)

Refactor of connection issue error
![image](https://user-images.githubusercontent.com/6598829/223881783-a38ead21-d8ef-46ec-9ec1-f0fd5f36e6b3.png)

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes #234 

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Add user friendly interface if dashboard crashes
RELEASE NOTES END
