### PR TITLE
fix typo in Makefile arg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ run-container-stg: build-stg
 
 build-stg:
 	$(CONTAINER_ENGINE) build --rm \
-		--build-arg REASCT_APP_API_URL=$(API_STG) \
+		--build-arg REACT_APP_API_URL=$(API_STG) \
 		--build-arg REACT_APP_GIT_SHA=$(GIT_SHA) \
 		-t $(IMAGE) -f Dockerfile .
 


### PR DESCRIPTION
There's a small typo

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Fix typo in Makefile for React
RELEASE NOTES END
