### PR TITLE
fix: propose downstream crashed the application

### DIFF
--- a/frontend/src/app/StatusLabel/BaseStatusLabel.tsx
+++ b/frontend/src/app/StatusLabel/BaseStatusLabel.tsx
@@ -3,7 +3,7 @@ import { Label, Tooltip } from "@patternfly/react-core";
 import { Link } from "react-router-dom";
 
 export interface BaseStatusLabelProps {
-    link: string;
+    link?: string;
     tooltipText: string;
     icon: React.ReactNode;
     color:
@@ -31,6 +31,9 @@ export const BaseStatusLabel: React.FC<BaseStatusLabelProps> = (props) => {
                     icon={props.icon}
                     color={props.color}
                     render={({ className, content, componentRef }) => {
+                        // the `downstream_pr_url` can be undefined if
+                        // looking at propose downstream job details
+                        if (!props.link) return <></>;
                         return props.link.startsWith("http") ? (
                             <a
                                 href={props.link}


### PR DESCRIPTION
This happened when the URL was null and we tried to use `startsWith` on it. For this to be fixed we have to assert that it is not null and proceed with the assumption that it can be null.

Specifically, this happens when propose downstrean doesn't have the `downstream_pr_url` attribute set.

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes
#254

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Fix propose downstream detailed view from crashing when downstream URL is null
RELEASE NOTES END
