### PR TITLE
Make 'make run-container-stg' work as expected

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,14 +11,14 @@ ENV HOME=/home/packit_dashboard
 
 WORKDIR /src
 
-COPY files/ files/
-
+COPY files/ansible/install-deps.yaml files/ansible/
 RUN ansible-playbook -vv -c local -i localhost, files/ansible/install-deps.yaml \
     && dnf clean all
 
 COPY packit_dashboard/  packit_dashboard/
 COPY frontend/ frontend/
 
+COPY files/ files/
 RUN ansible-playbook -vv -c local -i localhost, files/ansible/recipe.yaml
 
 EXPOSE 8443

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ run-dev-flask:
 	FLASK_ENV=development FLASK_APP=packit_dashboard.app flask-3 run --host=0.0.0.0
 
 run-container-stg: build-stg
-	$(CONTAINER_ENGINE) run --rm -p 8443:8443 -v $(CURDIR)/secrets:/secrets:z -i $(IMAGE)
+	$(CONTAINER_ENGINE) run -i --rm -u 1234 -p 8443:8443 -v $(CURDIR)/secrets:/secrets:ro,z $(IMAGE)
 
 build-stg:
 	$(CONTAINER_ENGINE) build --rm \

--- a/files/scripts/run_httpd.sh
+++ b/files/scripts/run_httpd.sh
@@ -2,9 +2,12 @@
 
 set -eux
 
-INSTANCE=
-if [ -n "${DEPLOYMENT}" ] && [ "${DEPLOYMENT}" != "prod" ]; then
-    INSTANCE=".${DEPLOYMENT}"
+if [[ "${DEPLOYMENT:=dev}" == "dev" ]]; then
+    SERVER_NAME="dashboard.localhost"
+elif [[ "${DEPLOYMENT}" == "prod" ]]; then
+    SERVER_NAME="dashboard.packit.dev"
+else
+    SERVER_NAME="dashboard.${DEPLOYMENT}.packit.dev"
 fi
 
 # See "mod_wsgi-express-3 start-server --help" for details on
@@ -20,7 +23,7 @@ exec mod_wsgi-express-3 start-server \
     --hsts-policy "max-age=31536000;includeSubDomains" \
     --ssl-certificate-file /secrets/fullchain.pem \
     --ssl-certificate-key-file /secrets/privkey.pem \
-    --server-name dashboard${INSTANCE}.packit.dev \
+    --server-name ${SERVER_NAME} \
     --processes 2 \
     --locale "C.UTF-8" \
     /usr/share/packit_dashboard/packit_dashboard.wsgi


### PR DESCRIPTION
I don't know how you guys run the dashboard locally, but I expected to try it in a container.
However the `README` suggests installing dependencies directly on the machine and running it there.

This is what I had to do to make 'make run-container-stg' work as (I) expected.