### PR TITLE
feat: change projects from cards to table

### DIFF
--- a/frontend/src/app/Projects/ProjectSearch.tsx
+++ b/frontend/src/app/Projects/ProjectSearch.tsx
@@ -9,6 +9,10 @@ import {
     GridItem,
     Button,
     TextInput,
+    Panel,
+    InputGroup,
+    PanelMain,
+    PanelMainBody,
 } from "@patternfly/react-core";
 
 import { SearchIcon } from "@patternfly/react-icons";
@@ -43,11 +47,11 @@ const ProjectSearch = () => {
     }
 
     return (
-        <Card>
-            <CardBody>
-                <Form>
-                    <Grid sm={6} md={4} lg={3} xl2={3}>
-                        <GridItem>
+        <Panel>
+            <PanelMain>
+                <PanelMainBody>
+                    <Form>
+                        <InputGroup>
                             <TextInput
                                 isRequired
                                 type="text"
@@ -58,8 +62,6 @@ const ProjectSearch = () => {
                                 placeholder="forge (e.g. github.com, required)"
                                 onChange={(e) => setForge(e)}
                             />
-                        </GridItem>
-                        <GridItem>
                             <TextInput
                                 isRequired
                                 type="text"
@@ -70,8 +72,6 @@ const ProjectSearch = () => {
                                 placeholder="the-namespace"
                                 onChange={(e) => setNamespace(e)}
                             />
-                        </GridItem>
-                        <GridItem>
                             <TextInput
                                 isRequired
                                 type="text"
@@ -82,24 +82,19 @@ const ProjectSearch = () => {
                                 placeholder="the-repo-name"
                                 onChange={(e) => setRepoName(e)}
                             />
-                        </GridItem>
-                        <GridItem>
-                            <Bullseye>
-                                <Button
-                                    variant="plain"
-                                    aria-label="Search"
-                                    onClick={goToProjectDetails}
-                                >
-                                    <SearchIcon />
-                                </Button>
-                            </Bullseye>
-                        </GridItem>
-                    </Grid>
-
-                    {invalidFormWarning}
-                </Form>
-            </CardBody>
-        </Card>
+                            <Button
+                                variant="plain"
+                                aria-label="Search"
+                                onClick={goToProjectDetails}
+                            >
+                                <SearchIcon />
+                            </Button>
+                        </InputGroup>
+                        {invalidFormWarning}
+                    </Form>
+                </PanelMainBody>
+            </PanelMain>
+        </Panel>
     );
 };
 

--- a/frontend/src/app/Projects/Projects.tsx
+++ b/frontend/src/app/Projects/Projects.tsx
@@ -4,6 +4,7 @@ import {
     PageSectionVariants,
     TextContent,
     Text,
+    PageGroup,
 } from "@patternfly/react-core";
 
 import { ProjectSearch } from "./ProjectSearch";
@@ -22,12 +23,12 @@ const Projects = () => {
                     </Text>
                 </TextContent>
             </PageSection>
-            <PageSection>
-                <ProjectSearch />
-            </PageSection>
-            <PageSection>
-                <ProjectsList />
-            </PageSection>
+            <PageGroup>
+                <PageSection>
+                    <ProjectSearch />
+                    <ProjectsList />
+                </PageSection>
+            </PageGroup>
         </>
     );
 };

--- a/frontend/src/app/Projects/Projects.tsx
+++ b/frontend/src/app/Projects/Projects.tsx
@@ -18,7 +18,7 @@ const Projects = () => {
                 <TextContent>
                     <Text component="h1">Projects</Text>
                     <Text component="p">
-                        List of repos with Packit Service enabled
+                        List of repositories with Packit Service enabled
                     </Text>
                 </TextContent>
             </PageSection>

--- a/frontend/src/app/Projects/ProjectsList.tsx
+++ b/frontend/src/app/Projects/ProjectsList.tsx
@@ -10,6 +10,8 @@ import {
     Gallery,
     GalleryItem,
     CardBody,
+    CardFooter,
+    CardHeader,
 } from "@patternfly/react-core";
 
 import {
@@ -96,22 +98,25 @@ const ProjectsList: React.FC<ProjectsListProps> = (props) => {
             <Gallery hasGutter>
                 {flatPages.map((project, index) => (
                     <GalleryItem key={index}>
-                        <Card>
-                            <CardTitle>
-                                <Link to={getProjectInfoURL(project)}>
-                                    {`${project.namespace}/${project.repo_name}`}
-                                </Link>
-                                <br />
-                                <a
-                                    href={project.project_url}
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    aria-label="External link to project"
-                                >
-                                    <ExternalLinkAltIcon />
-                                </a>
-                            </CardTitle>
-                            <CardBody>
+                        <Card isFullHeight>
+                            <CardHeader>
+                                <CardTitle>
+                                    <Link to={getProjectInfoURL(project)}>
+                                        {`${project.namespace}/${project.repo_name}`}
+                                    </Link>
+                                    <br />
+                                    <a
+                                        href={project.project_url}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        aria-label="External link to project"
+                                    >
+                                        <ExternalLinkAltIcon />
+                                    </a>
+                                </CardTitle>
+                            </CardHeader>
+                            <CardBody></CardBody>
+                            <CardFooter>
                                 <Flex>
                                     <FlexItem>
                                         <Tooltip
@@ -154,7 +159,7 @@ const ProjectsList: React.FC<ProjectsListProps> = (props) => {
                                         {project.prs_handled}
                                     </FlexItem>
                                 </Flex>
-                            </CardBody>
+                            </CardFooter>
                         </Card>
                     </GalleryItem>
                 ))}


### PR DESCRIPTION
We were using cards for the list itself, together with no differentiator
for each project, such as their icon, it made it very difficult to
browse in an easy way.

This change moves it over to a composable Table which we can use in
a future change to automatically fetch the branches, releases, and
issues for each project without leaving the page.

However, the table itself offers more information and gives less
confusion as to what each entry is and where to look to see the name --
the repository name will always be on the left side now, which it
didn't before

![image](https://github.com/packit/dashboard/assets/6598829/f00e51ac-68c0-4b54-ad74-018d3b7311e4)

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Our dashboard now shows projects in a table instead of the cards.
RELEASE NOTES END
