### PR TITLE
fix(gha): build args »need« to be on separate lines

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -50,7 +50,9 @@ jobs:
           dockerfiles: ${{ matrix.dockerfile }}
           image: ${{ matrix.image }}
           tags: ${{ steps.branch_tag.outputs.tag }}
-          build-args: VITE_API_URL=${{ steps.branch_tag.outputs.api }} VITE_GIT_SHA=${{ steps.branch_tag.outputs.commit_sha }}
+          build-args: |
+            VITE_API_URL=${{ steps.branch_tag.outputs.api }}
+            VITE_GIT_SHA=${{ steps.branch_tag.outputs.commit_sha }}
           oci: true
 
       - name: Push To Quay


### PR DESCRIPTION
In 67650a1, they have been put on one line, this doesn't work according to the documentation… and has already bitten me once before.

Revert this change and split them to multiple separate lines.