### PR TITLE
Don't install nodejs:18 (RPM) module

### DIFF
--- a/files/ansible/common.yaml
+++ b/files/ansible/common.yaml
@@ -15,7 +15,7 @@
   tags:
     - no-cache
   register: src_path
-- name: Let'secrets make sure {{ packit_dashboard_path }} is present
+- name: Make sure {{ packit_dashboard_path }} is present
   assert:
     that:
       - "src_path.stat.isdir"

--- a/files/ansible/install-deps.yaml
+++ b/files/ansible/install-deps.yaml
@@ -4,11 +4,6 @@
   vars:
     packit_dashboard_path: /src
   tasks:
-    - name: Enable nodejs:18
-      ansible.builtin.command:
-        cmd: dnf module enable -y nodejs:18/minimal
-        creates: /etc/dnf/modules.d/nodejs.module
-
     - name: Install all RPM/Python/Node packages needed to run dashboard
       dnf:
         name:

--- a/files/ansible/recipe.yaml
+++ b/files/ansible/recipe.yaml
@@ -18,9 +18,6 @@
         cmd: yarn install
 
     - name: bundle javascript
-      # TODO: remove this once the Node.js-stack stops using legacy crypto
-      environment:
-        NODE_OPTIONS: "--openssl-legacy-provider"
       command:
         chdir: "{{ packit_dashboard_path }}"
         cmd: yarn run build


### PR DESCRIPTION
F37 already contains `nodejs` 18 and I haven't seen any build problems.
C9S (#258) contains `nodejs` 16 but everything looks OK as well.

Fixes #247

Reverts 3cd34b74

@mfocko do you have any idea why @csomh started deleting the `/src/frontend/node_modules` in the 3cd34b74 and whether I should revert it too? I left it untouched (i.e. we still delete it) and it looks OK.