### PR TITLE
chore: add mockServiceWorker back to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,6 @@ modules.out
 
 # Makefile cache
 .install-logos
+
+# https://github.com/mswjs/msw/discussions/1015
+frontend/public/mockServiceWorker.js


### PR DESCRIPTION
Added in 519a111, removed during the rebase as a possible mistake.