### PR TITLE
Turn Pipeline ID into link to Testing Farm results

### DIFF
--- a/frontend/src/app/Results/ResultsPageTestingFarm.tsx
+++ b/frontend/src/app/Results/ResultsPageTestingFarm.tsx
@@ -156,7 +156,11 @@ const ResultsPageTestingFarm = () => {
                                     <td>
                                         <strong>Pipeline ID</strong>
                                     </td>
-                                    <td>{data.pipeline_id}</td>
+                                    <td>
+                                        <a href={data.web_url}>
+                                            {data.pipeline_id}
+                                        </a>
+                                    </td>
                                 </tr>
                                 <tr>
                                     <td>


### PR DESCRIPTION
Add a link on the Testing Farm Results page to the actual web_url for Testing Farm.

Fixes #276 

This is from the Contribute to an Open Source Service workshop at Devconf 2023.