### PR TITLE
Be consistent on the status for Copr and Koji builds

### DIFF
--- a/frontend/src/app/Results/ResultsPageCopr.tsx
+++ b/frontend/src/app/Results/ResultsPageCopr.tsx
@@ -7,6 +7,7 @@ import {
     TextContent,
     Text,
     Title,
+    Label,
 } from "@patternfly/react-core";
 
 import { ErrorConnection } from "../Errors/ErrorConnection";
@@ -195,11 +196,11 @@ const ResultsPageCopr = () => {
                                         <strong>SRPM Build</strong>
                                     </td>
                                     <td>
-                                        <a
+                                        <Label
                                             href={`/results/srpm-builds/${data.srpm_build_id}`}
                                         >
-                                            SRPM Logs
-                                        </a>
+                                            Details
+                                        </Label>
                                     </td>
                                 </tr>
                                 <tr>

--- a/frontend/src/app/Results/ResultsPageKoji.tsx
+++ b/frontend/src/app/Results/ResultsPageKoji.tsx
@@ -7,6 +7,7 @@ import {
     TextContent,
     Text,
     Title,
+    Label,
 } from "@patternfly/react-core";
 
 import { ErrorConnection } from "../Errors/ErrorConnection";
@@ -114,11 +115,11 @@ const ResultsPageKoji = () => {
                                         <strong>SRPM Build</strong>
                                     </td>
                                     <td>
-                                        <a
+                                        <Label
                                             href={`/results/srpm-builds/${data.srpm_build_id}`}
                                         >
-                                            SRPM Logs
-                                        </a>
+                                            Details
+                                        </Label>
                                     </td>
                                 </tr>
                                 <tr>


### PR DESCRIPTION
For Copr builds and Koji builds, we link the SRPM build result as SRPM
logs, which is misleading and should be changed to be consistent with
how we link Copr build results from Testing Farm results.

Fixes #263