### PR TITLE
Revert getXYZLink() to again accept forge instead of gitRepo

### DIFF
--- a/frontend/src/app/Results/ResultsPageCopr.tsx
+++ b/frontend/src/app/Results/ResultsPageCopr.tsx
@@ -17,7 +17,7 @@ import { StatusLabel } from "../StatusLabel/StatusLabel";
 import { Timestamp } from "../utils/Timestamp";
 import { useParams } from "react-router-dom";
 import { useTitle } from "../utils/useTitle";
-import { getCommitLink } from "../utils/forgeUrls";
+import { getCommitLink, getHostName } from "../utils/forgeUrls";
 import { useQuery } from "@tanstack/react-query";
 
 interface BuildPackage {
@@ -263,7 +263,7 @@ const ResultsPageCopr = () => {
                                     <td>
                                         <a
                                             href={getCommitLink(
-                                                data.git_repo,
+                                                getHostName(data.git_repo),
                                                 data.repo_namespace,
                                                 data.repo_name,
                                                 data.commit_sha,

--- a/frontend/src/app/Trigger/TriggerLink.tsx
+++ b/frontend/src/app/Trigger/TriggerLink.tsx
@@ -4,6 +4,7 @@ import {
     getBranchLink,
     getIssueLink,
     getReleaseLink,
+    getHostName,
 } from "../utils/forgeUrls";
 
 interface TriggerLinkProps {
@@ -36,7 +37,7 @@ const TriggerLink: React.FC<TriggerLinkProps> = (props) => {
         jobSuffix = `#${props.builds.pr_id}`;
 
         link = getPRLink(
-            gitRepo,
+            getHostName(gitRepo),
             props.builds.repo_namespace,
             props.builds.repo_name,
             props.builds.pr_id,
@@ -45,7 +46,7 @@ const TriggerLink: React.FC<TriggerLinkProps> = (props) => {
         jobSuffix = `#${props.builds.issue_id}`;
 
         link = getIssueLink(
-            gitRepo,
+            getHostName(gitRepo),
             props.builds.repo_namespace,
             props.builds.repo_name,
             props.builds.issue_id,
@@ -54,7 +55,7 @@ const TriggerLink: React.FC<TriggerLinkProps> = (props) => {
         jobSuffix = `:${props.builds.branch_name}`;
 
         link = getBranchLink(
-            gitRepo,
+            getHostName(gitRepo),
             props.builds.repo_namespace,
             props.builds.repo_name,
             props.builds.branch_name,
@@ -63,7 +64,7 @@ const TriggerLink: React.FC<TriggerLinkProps> = (props) => {
         jobSuffix = `#release:${props.builds.release}`;
 
         link = getReleaseLink(
-            gitRepo,
+            getHostName(gitRepo),
             props.builds.repo_namespace,
             props.builds.repo_name,
             props.builds.release,

--- a/frontend/src/app/utils/forgeUrls.tsx
+++ b/frontend/src/app/utils/forgeUrls.tsx
@@ -12,12 +12,11 @@ function getHostName(url: string | URL) {
 
 // getPRLink - returns the PR link if possible otherwise an empty string
 function getPRLink(
-    gitRepo: string,
+    forge: string,
     namespace: string,
     repoName: string,
     prID: number,
 ) {
-    const forge = getHostName(gitRepo);
     let prLink = `https://${forge}/${namespace}/${repoName}`;
     switch (forge) {
         case "github.com":
@@ -35,12 +34,11 @@ function getPRLink(
 
 // getBranchLink - returns the branch link if possible otherwise an empty string
 function getBranchLink(
-    gitRepo: string,
+    forge: string,
     namespace: string,
     repoName: string,
     branchName: string,
 ) {
-    const forge = getHostName(gitRepo);
     let branchLink = `https://${forge}/${namespace}/${repoName}`;
     switch (forge) {
         case "github.com":
@@ -58,12 +56,11 @@ function getBranchLink(
 
 // getIssueLink - returns the issue link if possible otherwise an empty string
 function getIssueLink(
-    gitRepo: string,
+    forge: string,
     namespace: string,
     repoName: string,
     issueID: number,
 ) {
-    const forge = getHostName(gitRepo);
     let issueLink = `https://${forge}/${namespace}/${repoName}`;
     switch (forge) {
         case "github.com":
@@ -81,12 +78,11 @@ function getIssueLink(
 
 // getReleaseLink - returns the link to release if possible otherwise an empty string
 function getReleaseLink(
-    gitRepo: string,
+    forge: string,
     namespace: string,
     repoName: string,
     release: string,
 ) {
-    const forge = getHostName(gitRepo);
     let releaseLink = `https://${forge}/${namespace}/${repoName}`;
     switch (forge) {
         case "github.com":
@@ -104,12 +100,11 @@ function getReleaseLink(
 
 // getCommitLink - returns a link to the commit
 function getCommitLink(
-    gitRepo: string,
+    forge: string,
     namespace: string,
     repoName: string,
     commit_hash: string,
 ) {
-    const forge = getHostName(gitRepo);
     let commitLink = `https://${forge}/${namespace}/${repoName}`;
     switch (forge) {
         case "github.com":


### PR DESCRIPTION
I changed my mind after all :-)

Passing repo URL, namespace and name is redundant because namespace and name are in the URL. We could pass only the URL, but splitting it isn't that easy because the namespace can also contain the slash on GitLab.
