### PR TITLE
fix: popover showing up in wrong place

### DIFF
--- a/frontend/src/app/AppLayout/AppLayout.tsx
+++ b/frontend/src/app/AppLayout/AppLayout.tsx
@@ -61,6 +61,7 @@ const AppLayout = () => {
         <PageHeaderTools>
             <Popover
                 headerContent={"About open source"}
+                flipBehavior={["bottom-end"]}
                 bodyContent={
                     <TextContent>
                         <Text>


### PR DESCRIPTION
The about open source popover had an issue where it would show up in
the wrong location, causing issues when it comes to opening it sometimes.

We can fix this by forcing the popover to assume `bottom-end` flip behavior

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Fix popover resizing dashboard incorrectly
RELEASE NOTES END
