### PR TITLE
feat: Consistent results pages

### DIFF
--- a/frontend/src/app/Results/ResultsPageCopr.tsx
+++ b/frontend/src/app/Results/ResultsPageCopr.tsx
@@ -24,6 +24,7 @@ import { useParams } from "react-router-dom";
 import { useTitle } from "../utils/useTitle";
 import { getCommitLink } from "../utils/forgeUrls";
 import { useQuery } from "@tanstack/react-query";
+import { ResultsPageCoprDetails } from "./ResultsPageCoprDetails";
 
 interface BuildPackage {
     arch: string;
@@ -120,56 +121,6 @@ const ResultsPageCopr = () => {
         );
     }
 
-    const packagesInstallationInstructions = data.built_packages ? (
-        <ListItem>
-            <code>
-                sudo dnf install -y{" "}
-                {getPackagesToInstall(data.built_packages).join(" ")}
-            </code>
-        </ListItem>
-    ) : (
-        ""
-    );
-
-    const installationInstructions =
-        data.status === "success" ? (
-            <Card>
-                <CardBody>
-                    <Text component="p">
-                        <strong>
-                            You can install the built RPMs by following these
-                            steps:
-                        </strong>
-                    </Text>
-                    <br />
-                    <List>
-                        <ListItem>
-                            <code>sudo yum install -y dnf-plugins-core</code> on
-                            RHEL 8 or CentOS Stream
-                        </ListItem>
-                        <ListItem>
-                            <code>sudo dnf install -y dnf-plugins-core</code> on
-                            Fedora
-                        </ListItem>
-                        <ListItem>
-                            <code>
-                                sudo dnf copr enable {data.copr_owner}/
-                                {data.copr_project}
-                            </code>
-                        </ListItem>
-                        {packagesInstallationInstructions}
-                    </List>
-                    <Text component="p">
-                        <br />
-                        Please note that the RPMs should be used only in a
-                        testing environment.
-                    </Text>
-                </CardBody>
-            </Card>
-        ) : (
-            ""
-        );
-
     return (
         <>
             <PageSection variant={PageSectionVariants.light}>
@@ -192,93 +143,57 @@ const ResultsPageCopr = () => {
             <PageSection>
                 <Card>
                     <CardBody>
-                        <DescriptionList
-                            columnModifier={{
-                                default: "1Col",
-                                sm: "2Col",
-                            }}
-                        >
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>
-                                    SRPM Build
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <Label
-                                        href={`/results/srpm-builds/${data.srpm_build_id}`}
-                                    >
-                                        Details
-                                    </Label>
-                                </DescriptionListDescription>
-                                <DescriptionListTerm>
-                                    Copr build
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <a
-                                        href={data.web_url}
-                                        rel="noreferrer"
-                                        target={"_blank"}
-                                    >
-                                        {data.build_id}
-                                    </a>{" "}
-                                    (
-                                    <a
-                                        href={data.build_logs_url}
-                                        rel="noreferrer"
-                                        target={"_blank"}
-                                    >
-                                        Logs
-                                    </a>
-                                    )
-                                </DescriptionListDescription>
-                                <DescriptionListTerm>
-                                    Commit SHA
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <a
-                                        href={getCommitLink(
-                                            data.git_repo,
-                                            data.commit_sha,
-                                        )}
-                                        rel="noreferrer"
-                                        target="_blank"
-                                    >
-                                        {data.commit_sha.substring(0, 7)}
-                                    </a>
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>
-                                    Build Submitted Time
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <Timestamp
-                                        stamp={data.build_submitted_time}
-                                        verbose={true}
-                                    />
-                                </DescriptionListDescription>
-                                <DescriptionListTerm>
-                                    Build Start Time
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <Timestamp
-                                        stamp={data.build_start_time}
-                                        verbose={true}
-                                    />
-                                </DescriptionListDescription>
-                                <DescriptionListTerm>
-                                    Build Finish Time
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <Timestamp
-                                        stamp={data.build_finished_time}
-                                        verbose={true}
-                                    />
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                        </DescriptionList>
+                        <ResultsPageCoprDetails data={data} />
                     </CardBody>
                 </Card>
-                {installationInstructions}
+                <Card>
+                    <CardBody>
+                        <Text component="p">
+                            <strong>
+                                You can install the built RPMs by following
+                                these steps:
+                            </strong>
+                        </Text>
+                        <br />
+                        <List>
+                            <ListItem>
+                                <code>
+                                    sudo yum install -y dnf-plugins-core
+                                </code>{" "}
+                                on RHEL 8 or CentOS Stream
+                            </ListItem>
+                            <ListItem>
+                                <code>
+                                    sudo dnf install -y dnf-plugins-core
+                                </code>{" "}
+                                on Fedora
+                            </ListItem>
+                            <ListItem>
+                                <code>
+                                    sudo dnf copr enable {data.copr_owner}/
+                                    {data.copr_project}
+                                </code>
+                            </ListItem>
+                            {data.built_packages ? (
+                                <ListItem>
+                                    <code>
+                                        sudo dnf install -y{" "}
+                                        {getPackagesToInstall(
+                                            data.built_packages,
+                                        ).join(" ")}
+                                    </code>
+                                </ListItem>
+                            ) : (
+                                <></>
+                            )}
+                        </List>
+                        <Text component="p">
+                            <br />
+                            Please note that the RPMs should be used only in a
+                            testing environment.
+                        </Text>
+                    </CardBody>
+                </Card>
             </PageSection>
         </>
     );

--- a/frontend/src/app/Results/ResultsPageCopr.tsx
+++ b/frontend/src/app/Results/ResultsPageCopr.tsx
@@ -8,6 +8,12 @@ import {
     Text,
     Title,
     Label,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    List,
+    ListItem,
 } from "@patternfly/react-core";
 
 import { ErrorConnection } from "../Errors/ErrorConnection";
@@ -114,12 +120,12 @@ const ResultsPageCopr = () => {
     }
 
     const packagesInstallationInstructions = data.built_packages ? (
-        <li>
+        <ListItem>
             <code>
                 sudo dnf install -y{" "}
                 {getPackagesToInstall(data.built_packages).join(" ")}
             </code>
-        </li>
+        </ListItem>
     ) : (
         ""
     );
@@ -135,23 +141,23 @@ const ResultsPageCopr = () => {
                         </strong>
                     </Text>
                     <br />
-                    <ul className="pf-c-list">
-                        <li>
+                    <List>
+                        <ListItem>
                             <code>sudo yum install -y dnf-plugins-core</code> on
                             RHEL 8 or CentOS Stream
-                        </li>
-                        <li>
+                        </ListItem>
+                        <ListItem>
                             <code>sudo dnf install -y dnf-plugins-core</code> on
                             Fedora
-                        </li>
-                        <li>
+                        </ListItem>
+                        <ListItem>
                             <code>
                                 sudo dnf copr enable {data.copr_owner}/
                                 {data.copr_project}
                             </code>
-                        </li>
+                        </ListItem>
                         {packagesInstallationInstructions}
-                    </ul>
+                    </List>
                     <Text component="p">
                         <br />
                         Please note that the RPMs should be used only in a
@@ -164,7 +170,7 @@ const ResultsPageCopr = () => {
         );
 
     return (
-        <div>
+        <>
             <PageSection variant={PageSectionVariants.light}>
                 <TextContent>
                     <Text component="h1">Copr Build Results</Text>
@@ -185,101 +191,100 @@ const ResultsPageCopr = () => {
             <PageSection>
                 <Card>
                     <CardBody>
-                        {/* TODO: Change to PatternFly table component */}
-                        <table
-                            className="pf-c-table pf-m-compact pf-m-grid-md"
-                            role="grid"
-                            aria-label="Builds Table"
+                        <DescriptionList
+                            columnModifier={{
+                                default: "1Col",
+                                sm: "2Col",
+                            }}
                         >
-                            <tbody>
-                                <tr>
-                                    <td>
-                                        <strong>SRPM Build</strong>
-                                    </td>
-                                    <td>
-                                        <Label
-                                            href={`/results/srpm-builds/${data.srpm_build_id}`}
-                                        >
-                                            Details
-                                        </Label>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Copr URL</strong>
-                                    </td>
-                                    <td>
-                                        <a href={data.web_url}>Web URL</a>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Build Logs</strong>
-                                    </td>
-                                    <td>
-                                        <a href={data.build_logs_url}>
-                                            Build Logs URL
-                                        </a>
-                                    </td>
-                                </tr>
-
-                                <tr>
-                                    <td>
-                                        <strong>Build Submission Time</strong>
-                                    </td>
-                                    <td>
-                                        <Timestamp
-                                            stamp={data.build_submitted_time}
-                                            verbose={true}
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Build Start Time</strong>
-                                    </td>
-                                    <td>
-                                        <Timestamp
-                                            stamp={data.build_start_time}
-                                            verbose={true}
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Build Finish Time</strong>
-                                    </td>
-                                    <td>
-                                        <Timestamp
-                                            stamp={data.build_finished_time}
-                                            verbose={true}
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Commit SHA</strong>
-                                    </td>
-                                    <td>
-                                        <a
-                                            href={getCommitLink(
-                                                data.git_repo,
-                                                data.commit_sha,
-                                            )}
-                                            rel="noreferrer"
-                                            target="_blank"
-                                        >
-                                            {data.commit_sha}
-                                        </a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    SRPM Build
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <Label
+                                        href={`/results/srpm-builds/${data.srpm_build_id}`}
+                                    >
+                                        Details
+                                    </Label>
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Copr URL
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <a
+                                        href={data.web_url}
+                                        rel="noreferrer"
+                                        target={"_blank"}
+                                    >
+                                        Web URL
+                                    </a>
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Build Logs
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <a
+                                        href={data.build_logs_url}
+                                        rel="noreferrer"
+                                        target={"_blank"}
+                                    >
+                                        Build Logs URL
+                                    </a>
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    Build Submitted Time
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <Timestamp
+                                        stamp={data.build_submitted_time}
+                                        verbose={true}
+                                    />
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Build Start Time
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <Timestamp
+                                        stamp={data.build_start_time}
+                                        verbose={true}
+                                    />
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Build Finish Time
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <Timestamp
+                                        stamp={data.build_finished_time}
+                                        verbose={true}
+                                    />
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    Commit SHA
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <a
+                                        href={getCommitLink(
+                                            data.git_repo,
+                                            data.commit_sha,
+                                        )}
+                                        rel="noreferrer"
+                                        target="_blank"
+                                    >
+                                        {data.commit_sha}
+                                    </a>
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </DescriptionList>
                     </CardBody>
                 </Card>
                 {installationInstructions}
             </PageSection>
-        </div>
+        </>
     );
 };
 

--- a/frontend/src/app/Results/ResultsPageCopr.tsx
+++ b/frontend/src/app/Results/ResultsPageCopr.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
     PageSection,
     Card,
@@ -34,7 +33,7 @@ interface BuildPackage {
     version: string;
 }
 
-interface CoprResult {
+export interface CoprResult {
     build_id: string;
     status: string;
     chroot: string;
@@ -78,7 +77,7 @@ function getPackagesToInstall(built_packages: BuildPackage[]) {
     return packagesToInstall;
 }
 
-const fetchSyncRelease = (url: string) =>
+export const fetchSyncRelease = (url: string) =>
     fetch(url).then((response) => {
         if (!response.ok && response.status !== 404) {
             throw Promise.reject(response);
@@ -86,11 +85,13 @@ const fetchSyncRelease = (url: string) =>
         return response.json();
     });
 
+export const API_COPR_BUILDS = `${import.meta.env.VITE_API_URL}/copr-builds/`;
+
 const ResultsPageCopr = () => {
     useTitle("Copr Results");
     let { id } = useParams();
+    const URL = API_COPR_BUILDS + id;
 
-    const URL = `${import.meta.env.VITE_API_URL}/copr-builds/${id}`;
     const { data, isError, isInitialLoading } = useQuery<
         CoprResult | { error: string }
     >([URL], () => fetchSyncRelease(URL));
@@ -209,7 +210,7 @@ const ResultsPageCopr = () => {
                                     </Label>
                                 </DescriptionListDescription>
                                 <DescriptionListTerm>
-                                    Copr URL
+                                    Copr build
                                 </DescriptionListTerm>
                                 <DescriptionListDescription>
                                     <a
@@ -217,19 +218,31 @@ const ResultsPageCopr = () => {
                                         rel="noreferrer"
                                         target={"_blank"}
                                     >
-                                        Web URL
-                                    </a>
-                                </DescriptionListDescription>
-                                <DescriptionListTerm>
-                                    Build Logs
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
+                                        {data.build_id}
+                                    </a>{" "}
+                                    (
                                     <a
                                         href={data.build_logs_url}
                                         rel="noreferrer"
                                         target={"_blank"}
                                     >
-                                        Build Logs URL
+                                        Logs
+                                    </a>
+                                    )
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Commit SHA
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <a
+                                        href={getCommitLink(
+                                            data.git_repo,
+                                            data.commit_sha,
+                                        )}
+                                        rel="noreferrer"
+                                        target="_blank"
+                                    >
+                                        {data.commit_sha.substring(0, 7)}
                                     </a>
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
@@ -260,23 +273,6 @@ const ResultsPageCopr = () => {
                                         stamp={data.build_finished_time}
                                         verbose={true}
                                     />
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>
-                                    Commit SHA
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <a
-                                        href={getCommitLink(
-                                            data.git_repo,
-                                            data.commit_sha,
-                                        )}
-                                        rel="noreferrer"
-                                        target="_blank"
-                                    >
-                                        {data.commit_sha}
-                                    </a>
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                         </DescriptionList>

--- a/frontend/src/app/Results/ResultsPageCopr.tsx
+++ b/frontend/src/app/Results/ResultsPageCopr.tsx
@@ -13,6 +13,7 @@ import {
     DescriptionListTerm,
     List,
     ListItem,
+    ClipboardCopy,
 } from "@patternfly/react-core";
 
 import { ErrorConnection } from "../Errors/ErrorConnection";
@@ -25,6 +26,7 @@ import { useTitle } from "../utils/useTitle";
 import { getCommitLink } from "../utils/forgeUrls";
 import { useQuery } from "@tanstack/react-query";
 import { ResultsPageCoprDetails } from "./ResultsPageCoprDetails";
+import { SHACopy } from "../utils/SHACopy";
 
 interface BuildPackage {
     arch: string;
@@ -126,16 +128,14 @@ const ResultsPageCopr = () => {
             <PageSection variant={PageSectionVariants.light}>
                 <TextContent>
                     <Text component="h1">Copr Build Results</Text>
-                    <StatusLabel
-                        target={data.chroot}
-                        status={data.status}
-                        link={data.web_url}
-                    />
                     <Text component="p">
                         <strong>
                             <TriggerLink builds={data} />
+                            <SHACopy
+                                git_repo={data.git_repo}
+                                commit_sha={data.commit_sha}
+                            />
                         </strong>
-                        <br />
                     </Text>
                 </TextContent>
             </PageSection>

--- a/frontend/src/app/Results/ResultsPageCoprDetails.tsx
+++ b/frontend/src/app/Results/ResultsPageCoprDetails.tsx
@@ -11,6 +11,7 @@ import { Timestamp } from "../utils/Timestamp";
 import { getCommitLink } from "../utils/forgeUrls";
 import { CoprResult } from "./ResultsPageCopr";
 import React from "react";
+import { StatusLabel } from "../StatusLabel/StatusLabel";
 
 export interface ResultsPageCoprDetailsProps {
     data: CoprResult;
@@ -35,9 +36,11 @@ export const ResultsPageCoprDetails: React.FC<ResultsPageCoprDetailsProps> = ({
                 </DescriptionListDescription>
                 <DescriptionListTerm>Copr build</DescriptionListTerm>
                 <DescriptionListDescription>
-                    <a href={data.web_url} rel="noreferrer" target={"_blank"}>
-                        {data.build_id}
-                    </a>{" "}
+                    <StatusLabel
+                        target={data.chroot}
+                        status={data.status}
+                        link={data.web_url}
+                    />
                     (
                     <a
                         href={data.build_logs_url}
@@ -47,16 +50,6 @@ export const ResultsPageCoprDetails: React.FC<ResultsPageCoprDetailsProps> = ({
                         Logs
                     </a>
                     )
-                </DescriptionListDescription>
-                <DescriptionListTerm>Commit SHA</DescriptionListTerm>
-                <DescriptionListDescription>
-                    <a
-                        href={getCommitLink(data.git_repo, data.commit_sha)}
-                        rel="noreferrer"
-                        target="_blank"
-                    >
-                        {data.commit_sha.substring(0, 7)}
-                    </a>
                 </DescriptionListDescription>
             </DescriptionListGroup>
             <DescriptionListGroup>

--- a/frontend/src/app/Results/ResultsPageCoprDetails.tsx
+++ b/frontend/src/app/Results/ResultsPageCoprDetails.tsx
@@ -1,0 +1,84 @@
+import {
+    Card,
+    CardBody,
+    Label,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
+} from "@patternfly/react-core";
+import { Timestamp } from "../utils/Timestamp";
+import { getCommitLink } from "../utils/forgeUrls";
+import { CoprResult } from "./ResultsPageCopr";
+import React from "react";
+
+export interface ResultsPageCoprDetailsProps {
+    data: CoprResult;
+}
+
+export const ResultsPageCoprDetails: React.FC<ResultsPageCoprDetailsProps> = ({
+    data,
+}) => {
+    return (
+        <DescriptionList
+            columnModifier={{
+                default: "1Col",
+                sm: "2Col",
+            }}
+        >
+            <DescriptionListGroup>
+                <DescriptionListTerm>SRPM Build</DescriptionListTerm>
+                <DescriptionListDescription>
+                    <Label href={`/results/srpm-builds/${data.srpm_build_id}`}>
+                        Details
+                    </Label>
+                </DescriptionListDescription>
+                <DescriptionListTerm>Copr build</DescriptionListTerm>
+                <DescriptionListDescription>
+                    <a href={data.web_url} rel="noreferrer" target={"_blank"}>
+                        {data.build_id}
+                    </a>{" "}
+                    (
+                    <a
+                        href={data.build_logs_url}
+                        rel="noreferrer"
+                        target={"_blank"}
+                    >
+                        Logs
+                    </a>
+                    )
+                </DescriptionListDescription>
+                <DescriptionListTerm>Commit SHA</DescriptionListTerm>
+                <DescriptionListDescription>
+                    <a
+                        href={getCommitLink(data.git_repo, data.commit_sha)}
+                        rel="noreferrer"
+                        target="_blank"
+                    >
+                        {data.commit_sha.substring(0, 7)}
+                    </a>
+                </DescriptionListDescription>
+            </DescriptionListGroup>
+            <DescriptionListGroup>
+                <DescriptionListTerm>Build Submitted Time</DescriptionListTerm>
+                <DescriptionListDescription>
+                    <Timestamp
+                        stamp={data.build_submitted_time}
+                        verbose={true}
+                    />
+                </DescriptionListDescription>
+                <DescriptionListTerm>Build Start Time</DescriptionListTerm>
+                <DescriptionListDescription>
+                    <Timestamp stamp={data.build_start_time} verbose={true} />
+                </DescriptionListDescription>
+                <DescriptionListTerm>Build Finish Time</DescriptionListTerm>
+                <DescriptionListDescription>
+                    <Timestamp
+                        stamp={data.build_finished_time}
+                        verbose={true}
+                    />
+                </DescriptionListDescription>
+            </DescriptionListGroup>
+        </DescriptionList>
+    );
+};

--- a/frontend/src/app/Results/ResultsPageKoji.tsx
+++ b/frontend/src/app/Results/ResultsPageKoji.tsx
@@ -8,6 +8,10 @@ import {
     Text,
     Title,
     Label,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
 } from "@patternfly/react-core";
 
 import { ErrorConnection } from "../Errors/ErrorConnection";
@@ -83,7 +87,7 @@ const ResultsPageKoji = () => {
     }
 
     return (
-        <div>
+        <>
             <PageSection variant={PageSectionVariants.light}>
                 <TextContent>
                     <Text component="h1">Koji Build Results</Text>
@@ -104,100 +108,99 @@ const ResultsPageKoji = () => {
             <PageSection>
                 <Card>
                     <CardBody>
-                        {/* TODO: Change to PatternFly table component */}
-                        <table
-                            className="pf-c-table pf-m-compact pf-m-grid-md"
-                            role="grid"
-                            aria-label="Builds Table"
+                        <DescriptionList
+                            columnModifier={{
+                                default: "1Col",
+                                sm: "2Col",
+                            }}
                         >
-                            <tbody>
-                                <tr>
-                                    <td>
-                                        <strong>SRPM Build</strong>
-                                    </td>
-                                    <td>
-                                        <Label
-                                            href={`/results/srpm-builds/${data.srpm_build_id}`}
-                                        >
-                                            Details
-                                        </Label>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Koji URL</strong>
-                                    </td>
-                                    <td>
-                                        <a href={data.web_url}>Web URL</a>
-                                    </td>
-                                </tr>
-                                {/*                                 <tr> */}
-                                {/*                                     <td> */}
-                                {/*                                         <strong>Build Logs</strong> */}
-                                {/*                                     </td> */}
-                                {/*                                     <td> */}
-                                {/*                                         <a href={data.build_logs_url}> */}
-                                {/*                                             Build Logs URL */}
-                                {/*                                         </a> */}
-                                {/*                                     </td> */}
-                                {/*                                 </tr> */}
-
-                                <tr>
-                                    <td>
-                                        <strong>Build Submission Time</strong>
-                                    </td>
-                                    <td>
-                                        <Timestamp
-                                            stamp={data.build_submitted_time}
-                                            verbose={true}
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Build Start Time</strong>
-                                    </td>
-                                    <td>
-                                        <Timestamp
-                                            stamp={data.build_start_time}
-                                            verbose={true}
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Build Finish Time</strong>
-                                    </td>
-                                    <td>
-                                        <Timestamp
-                                            stamp={data.build_finished_time}
-                                            verbose={true}
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Commit SHA</strong>
-                                    </td>
-                                    <td>
-                                        <a
-                                            href={getCommitLink(
-                                                data.git_repo,
-                                                data.commit_sha,
-                                            )}
-                                            rel="noreferrer"
-                                            target="_blank"
-                                        >
-                                            {data.commit_sha}
-                                        </a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    SRPM Build
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <Label
+                                        href={`/results/srpm-builds/${data.srpm_build_id}`}
+                                    >
+                                        Details
+                                    </Label>
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Koji URL
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <a
+                                        href={data.web_url}
+                                        rel="noreferrer"
+                                        target={"_blank"}
+                                    >
+                                        Web URL
+                                    </a>
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Build Logs
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <a
+                                        href={data.build_logs_url}
+                                        rel="noreferrer"
+                                        target={"_blank"}
+                                    >
+                                        Build Logs URL
+                                    </a>
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    Build Submitted Time
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <Timestamp
+                                        stamp={data.build_submitted_time}
+                                        verbose={true}
+                                    />
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Build Start Time
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <Timestamp
+                                        stamp={data.build_start_time}
+                                        verbose={true}
+                                    />
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Build Finish Time
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <Timestamp
+                                        stamp={data.build_finished_time}
+                                        verbose={true}
+                                    />
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    Commit SHA
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <a
+                                        href={getCommitLink(
+                                            data.git_repo,
+                                            data.commit_sha,
+                                        )}
+                                        rel="noreferrer"
+                                        target="_blank"
+                                    >
+                                        {data.commit_sha}
+                                    </a>
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </DescriptionList>
                     </CardBody>
                 </Card>
             </PageSection>
-        </div>
+        </>
     );
 };
 

--- a/frontend/src/app/Results/ResultsPageKoji.tsx
+++ b/frontend/src/app/Results/ResultsPageKoji.tsx
@@ -23,6 +23,7 @@ import { useParams } from "react-router-dom";
 import { useTitle } from "../utils/useTitle";
 import { getCommitLink } from "../utils/forgeUrls";
 import { useQuery } from "@tanstack/react-query";
+import { SHACopy } from "../utils/SHACopy";
 
 interface KojiBuild {
     build_id: string;
@@ -91,14 +92,13 @@ const ResultsPageKoji = () => {
             <PageSection variant={PageSectionVariants.light}>
                 <TextContent>
                     <Text component="h1">Koji Build Results</Text>
-                    <StatusLabel
-                        target={data.chroot}
-                        status={data.status}
-                        link={data.web_url}
-                    />
                     <Text component="p">
                         <strong>
                             <TriggerLink builds={data} />
+                            <SHACopy
+                                git_repo={data.git_repo}
+                                commit_sha={data.commit_sha}
+                            />
                         </strong>
                         <br />
                     </Text>
@@ -129,13 +129,11 @@ const ResultsPageKoji = () => {
                                     Koji Build
                                 </DescriptionListTerm>
                                 <DescriptionListDescription>
-                                    <a
-                                        href={data.web_url}
-                                        rel="noreferrer"
-                                        target={"_blank"}
-                                    >
-                                        {data.build_id}
-                                    </a>{" "}
+                                    <StatusLabel
+                                        target={data.chroot}
+                                        status={data.status}
+                                        link={data.web_url}
+                                    />{" "}
                                     (
                                     <a
                                         href={data.build_logs_url}
@@ -145,21 +143,6 @@ const ResultsPageKoji = () => {
                                         Logs
                                     </a>
                                     )
-                                </DescriptionListDescription>
-                                <DescriptionListTerm>
-                                    Commit SHA
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <a
-                                        href={getCommitLink(
-                                            data.git_repo,
-                                            data.commit_sha,
-                                        )}
-                                        rel="noreferrer"
-                                        target="_blank"
-                                    >
-                                        {data.commit_sha.substring(0, 7)}
-                                    </a>
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                             <DescriptionListGroup>

--- a/frontend/src/app/Results/ResultsPageKoji.tsx
+++ b/frontend/src/app/Results/ResultsPageKoji.tsx
@@ -126,7 +126,7 @@ const ResultsPageKoji = () => {
                                     </Label>
                                 </DescriptionListDescription>
                                 <DescriptionListTerm>
-                                    Koji URL
+                                    Koji Build
                                 </DescriptionListTerm>
                                 <DescriptionListDescription>
                                     <a
@@ -134,19 +134,31 @@ const ResultsPageKoji = () => {
                                         rel="noreferrer"
                                         target={"_blank"}
                                     >
-                                        Web URL
-                                    </a>
-                                </DescriptionListDescription>
-                                <DescriptionListTerm>
-                                    Build Logs
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
+                                        {data.build_id}
+                                    </a>{" "}
+                                    (
                                     <a
                                         href={data.build_logs_url}
                                         rel="noreferrer"
                                         target={"_blank"}
                                     >
-                                        Build Logs URL
+                                        Logs
+                                    </a>
+                                    )
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Commit SHA
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <a
+                                        href={getCommitLink(
+                                            data.git_repo,
+                                            data.commit_sha,
+                                        )}
+                                        rel="noreferrer"
+                                        target="_blank"
+                                    >
+                                        {data.commit_sha.substring(0, 7)}
                                     </a>
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
@@ -177,23 +189,6 @@ const ResultsPageKoji = () => {
                                         stamp={data.build_finished_time}
                                         verbose={true}
                                     />
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>
-                                    Commit SHA
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <a
-                                        href={getCommitLink(
-                                            data.git_repo,
-                                            data.commit_sha,
-                                        )}
-                                        rel="noreferrer"
-                                        target="_blank"
-                                    >
-                                        {data.commit_sha}
-                                    </a>
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                         </DescriptionList>

--- a/frontend/src/app/Results/ResultsPageSRPM.tsx
+++ b/frontend/src/app/Results/ResultsPageSRPM.tsx
@@ -114,22 +114,6 @@ const ResultsPageSRPM = () => {
         "Not available"
     );
 
-    const coprLogsUrl = data.logs_url ? (
-        <a href={data.logs_url}>Logs URL</a>
-    ) : (
-        "Not available"
-    );
-
-    const coprInfo = data.copr_build_id ? (
-        <Text component="p">
-            Copr Web URL: <a href={data.copr_web_url}>URL</a>
-            <br />
-            Copr SRPM build logs: {coprLogsUrl}
-        </Text>
-    ) : (
-        ""
-    );
-
     const logs = data.copr_build_id ? (
         ""
     ) : (
@@ -162,10 +146,7 @@ const ResultsPageSRPM = () => {
             <PageSection variant={PageSectionVariants.light}>
                 <TextContent>
                     <Text component="h1">SRPM Build</Text>
-                    <StatusLabel
-                        status={data.status}
-                        link={data.copr_web_url}
-                    />
+
                     <Text component="p">
                         <strong>
                             <TriggerLink builds={data} />
@@ -185,39 +166,50 @@ const ResultsPageSRPM = () => {
                         >
                             <DescriptionListGroup>
                                 <DescriptionListTerm>
-                                    Copr Web URL
+                                    Status
                                 </DescriptionListTerm>
                                 <DescriptionListDescription>
-                                    {coprLogsUrl}
+                                    <StatusLabel
+                                        status={data.status}
+                                        link={data.copr_web_url}
+                                    />
                                 </DescriptionListDescription>
-                                <DescriptionListTerm>
-                                    Copr SRPM Build
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <a
-                                        href={data.copr_web_url}
-                                        rel="noreferrer"
-                                        target={"_blank"}
-                                    >
-                                        Build
-                                    </a>
-                                </DescriptionListDescription>
-                                <DescriptionListTerm>
-                                    Copr SRPM Results
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    {data.url ? (
-                                        <a
-                                            href={data.url}
-                                            rel="noreferrer"
-                                            target={"_blank"}
-                                        >
-                                            SRPM
-                                        </a>
-                                    ) : (
-                                        "Not available"
-                                    )}
-                                </DescriptionListDescription>
+                                {data.url ? (
+                                    <>
+                                        <DescriptionListTerm>
+                                            Copr
+                                        </DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <a
+                                                href={data.url}
+                                                rel="noreferrer"
+                                                target={"_blank"}
+                                            >
+                                                Results
+                                            </a>
+                                        </DescriptionListDescription>
+                                        <DescriptionListDescription>
+                                            <a
+                                                href={data.copr_web_url}
+                                                rel="noreferrer"
+                                                target={"_blank"}
+                                            >
+                                                Build
+                                            </a>{" "}
+                                            (
+                                            <a
+                                                href={data.logs_url}
+                                                rel="noreferrer"
+                                                target={"_blank"}
+                                            >
+                                                Logs
+                                            </a>
+                                            )
+                                        </DescriptionListDescription>
+                                    </>
+                                ) : (
+                                    <></>
+                                )}
                             </DescriptionListGroup>
                             <DescriptionListGroup>
                                 <DescriptionListTerm>

--- a/frontend/src/app/Results/ResultsPageSRPM.tsx
+++ b/frontend/src/app/Results/ResultsPageSRPM.tsx
@@ -166,36 +166,16 @@ const ResultsPageSRPM = () => {
                         >
                             <DescriptionListGroup>
                                 <DescriptionListTerm>
-                                    Status
+                                    Copr build
                                 </DescriptionListTerm>
                                 <DescriptionListDescription>
                                     <StatusLabel
                                         status={data.status}
                                         link={data.copr_web_url}
-                                    />
-                                </DescriptionListDescription>
-                                {data.url ? (
-                                    <>
-                                        <DescriptionListTerm>
-                                            Copr
-                                        </DescriptionListTerm>
-                                        <DescriptionListDescription>
-                                            <a
-                                                href={data.url}
-                                                rel="noreferrer"
-                                                target={"_blank"}
-                                            >
-                                                Results
-                                            </a>
-                                        </DescriptionListDescription>
-                                        <DescriptionListDescription>
-                                            <a
-                                                href={data.copr_web_url}
-                                                rel="noreferrer"
-                                                target={"_blank"}
-                                            >
-                                                Build
-                                            </a>{" "}
+                                    />{" "}
+                                    {data.url ? (
+                                        <>
+                                            {" "}
                                             (
                                             <a
                                                 href={data.logs_url}
@@ -204,12 +184,20 @@ const ResultsPageSRPM = () => {
                                             >
                                                 Logs
                                             </a>
+                                            ) (
+                                            <a
+                                                href={data.url}
+                                                rel="noreferrer"
+                                                target={"_blank"}
+                                            >
+                                                Results
+                                            </a>
                                             )
-                                        </DescriptionListDescription>
-                                    </>
-                                ) : (
-                                    <></>
-                                )}
+                                        </>
+                                    ) : (
+                                        <></>
+                                    )}
+                                </DescriptionListDescription>
                             </DescriptionListGroup>
                             <DescriptionListGroup>
                                 <DescriptionListTerm>

--- a/frontend/src/app/Results/ResultsPageSRPM.tsx
+++ b/frontend/src/app/Results/ResultsPageSRPM.tsx
@@ -10,6 +10,12 @@ import {
     Toolbar,
     ToolbarContent,
     ToolbarItem,
+    DescriptionList,
+    DescriptionListGroup,
+    DescriptionListTerm,
+    DescriptionListDescription,
+    Divider,
+    Label,
 } from "@patternfly/react-core";
 import { LogViewer, LogViewerSearch } from "@patternfly/react-log-viewer";
 
@@ -21,6 +27,7 @@ import { Timestamp } from "../utils/Timestamp";
 import { useParams } from "react-router-dom";
 import { useTitle } from "../utils/useTitle";
 import { useQuery } from "@tanstack/react-query";
+import { TableComposable, Td, Th, Tr } from "@patternfly/react-table";
 
 interface SRPMBuild {
     status: string;
@@ -92,25 +99,25 @@ const ResultsPageSRPM = () => {
     const submittedAt = data.build_submitted_time ? (
         <Timestamp stamp={data.build_submitted_time} verbose={true} />
     ) : (
-        "not available"
+        "Not available"
     );
 
     const startedAt = data.build_start_time ? (
         <Timestamp stamp={data.build_start_time} verbose={true} />
     ) : (
-        "not available"
+        "Not available"
     );
 
     const finishedAt = data.build_finished_time ? (
         <Timestamp stamp={data.build_finished_time} verbose={true} />
     ) : (
-        "not available"
+        "Not available"
     );
 
     const coprLogsUrl = data.logs_url ? (
         <a href={data.logs_url}>Logs URL</a>
     ) : (
-        "not available"
+        "Not available"
     );
 
     const coprInfo = data.copr_build_id ? (
@@ -151,7 +158,7 @@ const ResultsPageSRPM = () => {
     );
 
     return (
-        <div>
+        <>
             <PageSection variant={PageSectionVariants.light}>
                 <TextContent>
                     <Text component="h1">SRPM Build</Text>
@@ -163,21 +170,81 @@ const ResultsPageSRPM = () => {
                         <strong>
                             <TriggerLink builds={data} />
                         </strong>
-                        <br />
-                        Submitted at: {submittedAt}
-                        <br />
-                        Started at: {startedAt}
-                        <br />
-                        Finished at: {finishedAt}
-                        <br />
                     </Text>
-                    {coprInfo}
-                    <Text component="p">SRPM: {srpmURL}</Text>
                 </TextContent>
             </PageSection>
-
+            <Divider></Divider>
+            <PageSection>
+                <Card>
+                    <CardBody>
+                        <DescriptionList
+                            columnModifier={{
+                                default: "1Col",
+                                sm: "2Col",
+                            }}
+                        >
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    Copr Web URL
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {coprLogsUrl}
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Copr SRPM Build
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <a
+                                        href={data.copr_web_url}
+                                        rel="noreferrer"
+                                        target={"_blank"}
+                                    >
+                                        Build
+                                    </a>
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Copr SRPM Results
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {data.url ? (
+                                        <a
+                                            href={data.url}
+                                            rel="noreferrer"
+                                            target={"_blank"}
+                                        >
+                                            SRPM
+                                        </a>
+                                    ) : (
+                                        "Not available"
+                                    )}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    Build Submitted Time
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {submittedAt}
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Build Start Time
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {startedAt}
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Build Finish Time
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {finishedAt}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </DescriptionList>
+                    </CardBody>
+                </Card>
+            </PageSection>
             {logs}
-        </div>
+        </>
     );
 };
 

--- a/frontend/src/app/Results/ResultsPageSyncReleaseRuns.tsx
+++ b/frontend/src/app/Results/ResultsPageSyncReleaseRuns.tsx
@@ -14,6 +14,10 @@ import {
     Button,
     ToolbarGroup,
     Tooltip,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
 } from "@patternfly/react-core";
 
 import { ErrorConnection } from "../Errors/ErrorConnection";
@@ -102,7 +106,9 @@ const ResultsPageSyncReleaseRuns: React.FC<ResultsPageSyncReleaseRunsProps> = ({
     }
 
     const linkToDownstreamPR = data.downstream_pr_url ? (
-        <a href={data.downstream_pr_url}>Click here</a>
+        <a href={data.downstream_pr_url} rel="noreferrer" target="_blank">
+            Click here
+        </a>
     ) : (
         <>Link will be available after successful downstream PR submission.</>
     );
@@ -245,60 +251,58 @@ const ResultsPageSyncReleaseRuns: React.FC<ResultsPageSyncReleaseRunsProps> = ({
             <PageSection>
                 <Card>
                     <CardBody>
-                        {/* TODO: Change to PatternFly table component */}
-                        <table
-                            className="pf-c-table pf-m-compact pf-m-grid-md"
-                            role="grid"
-                            aria-label="Sync release table"
+                        <DescriptionList
+                            columnModifier={{
+                                default: "1Col",
+                                sm: "2Col",
+                            }}
                         >
-                            <tbody>
-                                <tr>
-                                    <td>
-                                        <strong>Status</strong>
-                                    </td>
-                                    <td>{data.status}</td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Submission Time</strong>
-                                    </td>
-                                    <td>
-                                        <Timestamp
-                                            stamp={data.submitted_time}
-                                            verbose={true}
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Start Time</strong>
-                                    </td>
-                                    <td>
-                                        <Timestamp
-                                            stamp={data.start_time}
-                                            verbose={true}
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Finish Time</strong>
-                                    </td>
-                                    <td>
-                                        <Timestamp
-                                            stamp={data.finished_time}
-                                            verbose={true}
-                                        />
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Link to downstream PR</strong>
-                                    </td>
-                                    <td>{linkToDownstreamPR}</td>
-                                </tr>
-                            </tbody>
-                        </table>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    Status
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {data.status}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    Submitted Time
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <Timestamp
+                                        stamp={data.submitted_time}
+                                        verbose={true}
+                                    />
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Start Time
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <Timestamp
+                                        stamp={data.start_time}
+                                        verbose={true}
+                                    />
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Finish Time
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <Timestamp
+                                        stamp={data.finished_time}
+                                        verbose={true}
+                                    />
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    Link to downstream PR
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {linkToDownstreamPR}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </DescriptionList>
                     </CardBody>
                 </Card>
             </PageSection>

--- a/frontend/src/app/Results/ResultsPageSyncReleaseRuns.tsx
+++ b/frontend/src/app/Results/ResultsPageSyncReleaseRuns.tsx
@@ -234,11 +234,6 @@ const ResultsPageSyncReleaseRuns: React.FC<ResultsPageSyncReleaseRunsProps> = ({
             <PageSection variant={PageSectionVariants.light}>
                 <TextContent>
                     <Text component="h1">{displayText}</Text>
-                    <SyncReleaseTargetStatusLabel
-                        status={data.status}
-                        target={data.branch}
-                        link={data.downstream_pr_url}
-                    />
                     <Text component="p">
                         <strong>
                             <TriggerLink builds={data} />
@@ -262,7 +257,11 @@ const ResultsPageSyncReleaseRuns: React.FC<ResultsPageSyncReleaseRunsProps> = ({
                                     Status
                                 </DescriptionListTerm>
                                 <DescriptionListDescription>
-                                    {data.status}
+                                    <SyncReleaseTargetStatusLabel
+                                        status={data.status}
+                                        target={data.branch}
+                                        link={data.downstream_pr_url}
+                                    />
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                             <DescriptionListGroup>
@@ -292,14 +291,6 @@ const ResultsPageSyncReleaseRuns: React.FC<ResultsPageSyncReleaseRunsProps> = ({
                                         stamp={data.finished_time}
                                         verbose={true}
                                     />
-                                </DescriptionListDescription>
-                            </DescriptionListGroup>
-                            <DescriptionListGroup>
-                                <DescriptionListTerm>
-                                    Link to downstream PR
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    {linkToDownstreamPR}
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                         </DescriptionList>

--- a/frontend/src/app/Results/ResultsPageTestingFarm.tsx
+++ b/frontend/src/app/Results/ResultsPageTestingFarm.tsx
@@ -97,7 +97,6 @@ function useCoprBuilds(copr_build_ids: number[]): React.JSX.Element[] {
     const coprDetails = results.map((result) => {
         if (!result.data || typeof result.data !== "object")
             return <>Loading</>;
-        console.log(result.data);
         if ("error" in result.data) {
             return <>Error {result.data["error"]}</>;
         } else if ("build_id" in result.data) {
@@ -195,6 +194,12 @@ const ResultsPageTestingFarm = () => {
         <>{data?.status}</>
     );
 
+    const onCopyHash = () => {
+        if (data) {
+            navigator.clipboard.writeText(data.commit_sha.substring(0, 7));
+        }
+    };
+
     return (
         <>
             <PageSection variant={PageSectionVariants.light}>
@@ -203,7 +208,28 @@ const ResultsPageTestingFarm = () => {
 
                     <Text component="p">
                         <strong>
-                            {data ? <TriggerLink builds={data} /> : <></>}
+                            {data ? (
+                                <>
+                                    <TriggerLink builds={data} />
+                                    <ClipboardCopy
+                                        variant="inline-compact"
+                                        onCopy={onCopyHash}
+                                    >
+                                        <a
+                                            href={getCommitLink(
+                                                data.git_repo,
+                                                data.commit_sha,
+                                            )}
+                                            rel="noreferrer"
+                                            target="_blank"
+                                        >
+                                            {data.commit_sha.substring(0, 7)}
+                                        </a>
+                                    </ClipboardCopy>
+                                </>
+                            ) : (
+                                <></>
+                            )}
                         </strong>
                         <br />
                     </Text>
@@ -258,26 +284,6 @@ const ResultsPageTestingFarm = () => {
                                             >
                                                 {data.pipeline_id}
                                             </ClipboardCopy>
-                                        </DescriptionListDescription>
-                                    </DescriptionListGroup>
-                                    <DescriptionListGroup>
-                                        <DescriptionListTerm>
-                                            Commit SHA
-                                        </DescriptionListTerm>
-                                        <DescriptionListDescription>
-                                            <a
-                                                href={getCommitLink(
-                                                    data.git_repo,
-                                                    data.commit_sha,
-                                                )}
-                                                rel="noreferrer"
-                                                target="_blank"
-                                            >
-                                                {data.commit_sha.substring(
-                                                    0,
-                                                    7,
-                                                )}
-                                            </a>
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                 </DescriptionList>

--- a/frontend/src/app/Results/ResultsPageTestingFarm.tsx
+++ b/frontend/src/app/Results/ResultsPageTestingFarm.tsx
@@ -7,19 +7,16 @@ import {
     TextContent,
     Text,
     Title,
-    Label,
     DescriptionList,
     DescriptionListDescription,
     DescriptionListGroup,
     DescriptionListTerm,
-    Divider,
     DataList,
     DataListItemRow,
     DataListItem,
     DataListContent,
     DataListItemCells,
     DataListCell,
-    Spinner,
     DataListToggle,
     ClipboardCopy,
 } from "@patternfly/react-core";
@@ -29,6 +26,7 @@ import { TriggerLink } from "../Trigger/TriggerLink";
 import { StatusLabel } from "../StatusLabel/StatusLabel";
 import { NavLink, useParams } from "react-router-dom";
 import { useTitle } from "../utils/useTitle";
+import { Timestamp } from "../utils/Timestamp";
 import { getCommitLink } from "../utils/forgeUrls";
 import { QueriesOptions, useQueries, useQuery } from "@tanstack/react-query";
 import {
@@ -271,8 +269,6 @@ const ResultsPageTestingFarm = () => {
                                                 link={data.web_url}
                                             />
                                         </DescriptionListDescription>
-                                    </DescriptionListGroup>
-                                    <DescriptionListGroup>
                                         <DescriptionListTerm>
                                             Pipeline ID
                                         </DescriptionListTerm>
@@ -281,9 +277,21 @@ const ResultsPageTestingFarm = () => {
                                                 isReadOnly
                                                 hoverTip="Copy"
                                                 clickTip="Copied"
+                                                variant="inline-compact"
                                             >
                                                 {data.pipeline_id}
                                             </ClipboardCopy>
+                                        </DescriptionListDescription>
+                                    </DescriptionListGroup>
+                                    <DescriptionListGroup>
+                                        <DescriptionListTerm>
+                                            Run Submitted Time
+                                        </DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <Timestamp
+                                                stamp={data.submitted_time}
+                                                verbose={true}
+                                            />
                                         </DescriptionListDescription>
                                     </DescriptionListGroup>
                                 </DescriptionList>

--- a/frontend/src/app/Results/ResultsPageTestingFarm.tsx
+++ b/frontend/src/app/Results/ResultsPageTestingFarm.tsx
@@ -41,6 +41,7 @@ import {
 } from "./ResultsPageCopr";
 import { Preloader } from "../Preloader/Preloader";
 import { ResultsPageCoprDetails } from "./ResultsPageCoprDetails";
+import { SHACopy } from "../utils/SHACopy";
 
 export interface TestingFarmOverview {
     pipeline_id: string; // UUID
@@ -195,12 +196,6 @@ const ResultsPageTestingFarm = () => {
         <>{data?.status}</>
     );
 
-    const onCopyHash = () => {
-        if (data) {
-            navigator.clipboard.writeText(data.commit_sha);
-        }
-    };
-
     return (
         <>
             <PageSection variant={PageSectionVariants.light}>
@@ -212,26 +207,10 @@ const ResultsPageTestingFarm = () => {
                             {data ? (
                                 <>
                                     <TriggerLink builds={data} />
-                                    <ClipboardCopy
-                                        style={{
-                                            marginLeft:
-                                                "var(--pf-global--spacer--xs)",
-                                        }}
-                                        hoverTip="Copy commit SHA"
-                                        variant="inline-compact"
-                                        onCopy={onCopyHash}
-                                    >
-                                        <a
-                                            href={getCommitLink(
-                                                data.git_repo,
-                                                data.commit_sha,
-                                            )}
-                                            rel="noreferrer"
-                                            target="_blank"
-                                        >
-                                            {data.commit_sha.substring(0, 7)}
-                                        </a>
-                                    </ClipboardCopy>
+                                    <SHACopy
+                                        git_repo={data.git_repo}
+                                        commit_sha={data.commit_sha}
+                                    />
                                 </>
                             ) : (
                                 <></>

--- a/frontend/src/app/Results/ResultsPageTestingFarm.tsx
+++ b/frontend/src/app/Results/ResultsPageTestingFarm.tsx
@@ -8,6 +8,10 @@ import {
     Text,
     Title,
     Label,
+    DescriptionList,
+    DescriptionListDescription,
+    DescriptionListGroup,
+    DescriptionListTerm,
 } from "@patternfly/react-core";
 
 import { ErrorConnection } from "../Errors/ErrorConnection";
@@ -53,12 +57,12 @@ function getCoprBuilds(copr_build_ids: number[]) {
     }
 
     return (
-        <tr>
-            <td>
-                <strong>{title}</strong>
-            </td>
-            <td>{coprBuilds}</td>
-        </tr>
+        <>
+            <DescriptionListTerm>{title}</DescriptionListTerm>
+            <DescriptionListDescription>
+                {coprBuilds}
+            </DescriptionListDescription>
+        </>
     );
 }
 
@@ -106,7 +110,9 @@ const ResultsPageTestingFarm = () => {
     }
 
     const statusWithLink = data.web_url ? (
-        <a href={data.web_url}>{data.status}</a>
+        <a href={data.web_url} target="_blank" rel="noreferrer">
+            {data.status}
+        </a>
     ) : (
         <>{data.status}</>
     );
@@ -118,7 +124,7 @@ const ResultsPageTestingFarm = () => {
             : "";
 
     return (
-        <div>
+        <>
             <PageSection variant={PageSectionVariants.light}>
                 <TextContent>
                     <Text component="h1">Testing Farm Results</Text>
@@ -135,61 +141,62 @@ const ResultsPageTestingFarm = () => {
                     </Text>
                 </TextContent>
             </PageSection>
-
             <PageSection>
                 <Card>
                     <CardBody>
-                        {/* TODO: Change to PatternFly table component */}
-                        <table
-                            className="pf-c-table pf-m-compact pf-m-grid-md"
-                            role="grid"
-                            aria-label="Testing farm table"
+                        <DescriptionList
+                            columnModifier={{
+                                default: "1Col",
+                                sm: "2Col",
+                            }}
                         >
-                            <tbody>
-                                <tr>
-                                    <td>
-                                        <strong>Status</strong>
-                                    </td>
-                                    <td>{statusWithLink}</td>
-                                </tr>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    Status
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {statusWithLink}
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
                                 {coprBuildInfo}
-                                <tr>
-                                    <td>
-                                        <strong>Pipeline ID</strong>
-                                    </td>
-                                    <td>
-                                        <a
-                                            href={data.web_url}
-                                            rel="noreferrer"
-                                            target="_blank"
-                                        >
-                                            {data.pipeline_id}
-                                        </a>
-                                    </td>
-                                </tr>
-                                <tr>
-                                    <td>
-                                        <strong>Commit SHA</strong>
-                                    </td>
-                                    <td>
-                                        <a
-                                            href={getCommitLink(
-                                                data.git_repo,
-                                                data.commit_sha,
-                                            )}
-                                            rel="noreferrer"
-                                            target="_blank"
-                                        >
-                                            {data.commit_sha}
-                                        </a>
-                                    </td>
-                                </tr>
-                            </tbody>
-                        </table>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    Pipeline ID
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <a
+                                        href={data.web_url}
+                                        rel="noreferrer"
+                                        target="_blank"
+                                    >
+                                        {data.pipeline_id}
+                                    </a>
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                            <DescriptionListGroup>
+                                <DescriptionListTerm>
+                                    Commit SHA
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    <a
+                                        href={getCommitLink(
+                                            data.git_repo,
+                                            data.commit_sha,
+                                        )}
+                                        rel="noreferrer"
+                                        target="_blank"
+                                    >
+                                        {data.commit_sha}
+                                    </a>
+                                </DescriptionListDescription>
+                            </DescriptionListGroup>
+                        </DescriptionList>
                     </CardBody>
                 </Card>
             </PageSection>
-        </div>
+        </>
     );
 };
 

--- a/frontend/src/app/Results/ResultsPageTestingFarm.tsx
+++ b/frontend/src/app/Results/ResultsPageTestingFarm.tsx
@@ -197,7 +197,7 @@ const ResultsPageTestingFarm = () => {
 
     const onCopyHash = () => {
         if (data) {
-            navigator.clipboard.writeText(data.commit_sha.substring(0, 7));
+            navigator.clipboard.writeText(data.commit_sha);
         }
     };
 
@@ -213,6 +213,11 @@ const ResultsPageTestingFarm = () => {
                                 <>
                                     <TriggerLink builds={data} />
                                     <ClipboardCopy
+                                        style={{
+                                            marginLeft:
+                                                "var(--pf-global--spacer--xs)",
+                                        }}
+                                        hoverTip="Copy commit SHA"
                                         variant="inline-compact"
                                         onCopy={onCopyHash}
                                     >

--- a/frontend/src/app/utils/SHACopy.tsx
+++ b/frontend/src/app/utils/SHACopy.tsx
@@ -1,0 +1,39 @@
+import { ClipboardCopy } from "@patternfly/react-core";
+import React from "react";
+import { getCommitLink } from "./forgeUrls";
+
+export interface SHACopyInterface {
+    git_repo: string;
+    commit_sha: string;
+}
+
+export const SHACopy: React.FC<SHACopyInterface> = ({
+    git_repo,
+    commit_sha,
+}) => {
+    if (!git_repo || !commit_sha) {
+        return <></>;
+    }
+    const onCopyHash = () => {
+        navigator.clipboard.writeText(commit_sha);
+    };
+
+    return (
+        <ClipboardCopy
+            style={{
+                marginLeft: "var(--pf-global--spacer--xs)",
+            }}
+            hoverTip="Copy commit SHA"
+            variant="inline-compact"
+            onCopy={onCopyHash}
+        >
+            <a
+                href={getCommitLink(git_repo, commit_sha)}
+                rel="noreferrer"
+                target="_blank"
+            >
+                {commit_sha.substring(0, 7)}
+            </a>
+        </ClipboardCopy>
+    );
+};


### PR DESCRIPTION
This unifies the results to a better UX that should make it less confusing
while also having a consistent layout between different builds and runs

This idea is a change from table to a [description list](https://www.patternfly.org/v4/components/description-list)
![image](https://github.com/packit/dashboard/assets/6598829/39171815-5cc9-4973-b5db-ce8c5659b489)

Before and after for testing farm
![image](https://github.com/packit/dashboard/assets/6598829/9cf56afc-9eb6-43ed-8fa7-0ec0cd431a9a)

Before and after for Copr builds
![image](https://github.com/packit/dashboard/assets/6598829/26604782-a26a-4c99-b8aa-e755ffec62d4)

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes 
#288
#262

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Improve UX of results page
RELEASE NOTES END
