### PR TITLE
Harden automated build

### DIFF
--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Merge the changes with the ‹main›
         run: git merge --no-edit tmp
 
+      - name: Check out the script from the ‹main› branch
+        run: git checkout origin/main .github/notify.py
+
       - uses: actions/setup-node@v3
         with:
           node-version: 18

--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -17,10 +17,8 @@ jobs:
   deploy-preview:
     runs-on: ubuntu-20.04
     env:
-      SURGE_TOKEN: ${{ secrets.SURGE_TOKEN             }}
-      GH_PR_TOKEN: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}
-      GH_PR_NUM: ${{ github.event.inputs.pr_id || github.event.number }}
       DOMAIN: packit-dashboard-pr-${{ github.event.inputs.pr_id || github.event.number }}.surge.sh
+      GH_PR_NUM: ${{ github.event.inputs.pr_id || github.event.number }}
     steps:
       - name: Checkout the repository
         uses: actions/checkout@v3
@@ -56,9 +54,13 @@ jobs:
 
       - name: Deploy the dashboard to surge.sh
         run: surge ./frontend/dist $DOMAIN --token ${{ secrets.SURGE_TOKEN }}
+        env:
+          SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
 
       - name: Install ‹ogr›, cause why not
         run: python3 -m pip install ogr
 
       - name: Notify PR about the deployment
         run: python3 .github/notify.py $DOMAIN
+        env:
+          GH_PR_TOKEN: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}


### PR DESCRIPTION
* Expose the tokens only to the steps where the tokens are required.
* Do not merge the script used for notifications on the PRs.