### PR TITLE
Rename Koji Builds tab

### DIFF
--- a/frontend/src/app/Jobs/Jobs.tsx
+++ b/frontend/src/app/Jobs/Jobs.tsx
@@ -58,7 +58,7 @@ const Jobs = () => {
                                 isActive={currentMatch?.id === "koji-builds"}
                             >
                                 <NavLink to={"koji-builds"}>
-                                    Koji Builds
+                                    Upstream Koji Builds
                                 </NavLink>
                             </NavItem>
                             <NavItem

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -60,7 +60,7 @@ const routes: RouteObject[] = [
                         id: "koji-builds",
                         path: "koji-builds",
                         handle: {
-                            label: "Koji Builds",
+                            label: "Upstream Koji Builds",
                         },
                     },
                     {


### PR DESCRIPTION
Rename it to 'Upstream Koji Builds' to make it clear these are not the production ones triggered in downstream.


---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
