### PR TITLE
Adjust Copr build epoch handling for None

### DIFF
--- a/frontend/src/app/Results/ResultsPageCopr.tsx
+++ b/frontend/src/app/Results/ResultsPageCopr.tsx
@@ -60,7 +60,7 @@ function getPackagesToInstall(built_packages: BuildPackage[]) {
             const packageString =
                 packageDict.name +
                 "-" +
-                (packageDict.epoch !== 0 ? packageDict.epoch + ":" : "") +
+                (packageDict.epoch ? packageDict.epoch + ":" : "") +
                 packageDict.version +
                 "-" +
                 packageDict.release +


### PR DESCRIPTION
Adjust how we include the epoch in the build result page. We get the value in packit-service from Copr API and the behaviour there recently changed: https://github.com/fedora-copr/copr/pull/2876


---

RELEASE NOTES BEGIN
N/A
RELEASE NOTES END
