### PR TITLE
Usage trend charts

### DIFF
--- a/frontend/src/app/Usage/Usage.tsx
+++ b/frontend/src/app/Usage/Usage.tsx
@@ -11,6 +11,7 @@ import {
 } from "@patternfly/react-core";
 
 import { UsageList } from "./UsageList";
+import { UsageInterval } from "./UsageInterval";
 import { useTitle } from "../utils/useTitle";
 
 const Usage = () => {
@@ -43,15 +44,19 @@ const Usage = () => {
                         >
                             <Tab eventKey={0} title="Past day">
                                 <UsageList what="past-day" />
+                                <UsageInterval days={0} hours={1} count={24} />
                             </Tab>
                             <Tab eventKey={1} title="Past week">
                                 <UsageList what="past-week" />
+                                <UsageInterval days={1} hours={0} count={7} />
                             </Tab>
                             <Tab eventKey={2} title="Past month">
                                 <UsageList what="past-month" />
+                                <UsageInterval days={1} hours={0} count={30} />
                             </Tab>
                             <Tab eventKey={3} title="Past year">
                                 <UsageList what="past-year" />
+                                <UsageInterval days={7} hours={0} count={52} />
                             </Tab>
                         </Tabs>
                     </CardBody>

--- a/frontend/src/app/Usage/UsageInterval.tsx
+++ b/frontend/src/app/Usage/UsageInterval.tsx
@@ -154,7 +154,9 @@ const UsageInterval: React.FC<UsageIntervalProps> = (props) => {
                 <CardBody>
                     <Flex>
                         {getLineChart(
-                            Object.keys(data.jobs),
+                            Object.keys(data.jobs).filter(
+                                (obj) => obj !== "sync_release_runs",
+                            ),
                             data.jobs,
                             "Number of processed jobs",
                         )}

--- a/frontend/src/app/Usage/UsageInterval.tsx
+++ b/frontend/src/app/Usage/UsageInterval.tsx
@@ -1,0 +1,181 @@
+import {
+    PageSection,
+    Card,
+    CardBody,
+    Title,
+    Flex,
+    FlexItem,
+} from "@patternfly/react-core";
+import {
+    Chart,
+    ChartAxis,
+    ChartGroup,
+    ChartLine,
+    createContainer,
+    ChartLegendTooltip,
+} from "@patternfly/react-charts";
+
+import { ErrorConnection } from "../Errors/ErrorConnection";
+import { Preloader } from "../Preloader/Preloader";
+import { useQuery } from "@tanstack/react-query";
+import { UsageListData } from "./UsageListData";
+
+const fetchDataByGranularity = (granularity: UsageIntervalProps) =>
+    fetch(
+        `/api/usage/intervals?days=${granularity.days}&hours=${granularity.hours}&count=${granularity.count}`,
+    ).then((response) => response.json());
+
+interface UsageIntervalProps {
+    days: number;
+    hours: number;
+    count: number;
+}
+
+const UsageInterval: React.FC<UsageIntervalProps> = (props) => {
+    const { data, isInitialLoading, isError } = useQuery<UsageListData>(
+        [`usage-intervals-${props.days}-${props.hours}&-${props.count}`],
+        () => fetchDataByGranularity(props),
+        {
+            keepPreviousData: true,
+        },
+    );
+
+    // If backend API is down
+    if (isError) {
+        return <ErrorConnection />;
+    }
+
+    // Show preloader if waiting for API data
+    if (isInitialLoading) {
+        return <Preloader />;
+    }
+
+    if (!data || "error" in data) {
+        return (
+            <PageSection>
+                <Card>
+                    <CardBody>
+                        <Title headingLevel="h1" size="lg">
+                            Not Found.
+                        </Title>
+                    </CardBody>
+                </Card>
+            </PageSection>
+        );
+    }
+
+    function getReadableName(job_name: string) {
+        return job_name
+            .replaceAll("_", " ")
+            .toLowerCase()
+            .split(" ")
+            .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+            .join(" ")
+            .replace(" Groups", "s")
+            .replace(" Targets", "s")
+            .replace("Vm", "VM")
+            .replace("Tft", "TFT")
+            .replace("Srpm", "SRPM");
+    }
+
+    function getChartLine(
+        line_data: [{ name: string; x: string; y: number }],
+        name: string,
+    ) {
+        return <ChartLine data={line_data} name={getReadableName(name)} />;
+    }
+
+    function getLineChart(keysToShow, dataMapping, description) {
+        var CursorVoronoiContainer = createContainer("voronoi", "cursor");
+        var jobChartLineLegendData = keysToShow.map((key) => ({
+            childName: getReadableName(key),
+            name: getReadableName(key),
+        }));
+        var jobChartLines = keysToShow.map((key, i) =>
+            getChartLine(dataMapping[key], key),
+        );
+
+        return (
+            <FlexItem>
+                <Card>
+                    <CardBody>
+                        <div style={{ height: "250px", width: "500px" }}>
+                            <Chart
+                                ariaDesc="Packit usage trend chart"
+                                ariaTitle={`${description} (interval: ${props.days} days ${props.hours} hours)`}
+                                containerComponent={
+                                    <CursorVoronoiContainer
+                                        cursorDimension="x"
+                                        labels={({ datum }) => `${datum.y}`}
+                                        constrainToVisibleArea
+                                        labelComponent={
+                                            <ChartLegendTooltip
+                                                legendData={
+                                                    jobChartLineLegendData
+                                                }
+                                                title={(datum) => datum.x}
+                                            />
+                                        }
+                                        mouseFollowTooltips
+                                        voronoiDimension="x"
+                                    />
+                                }
+                                legendData={jobChartLineLegendData}
+                                legendOrientation="vertical"
+                                legendPosition="right"
+                                minDomain={{ y: 0 }}
+                                padding={{
+                                    bottom: 50,
+                                    left: 0, // Adjusted to accommodate axis label
+                                    right: 100, // Adjusted to accommodate legend
+                                    top: 20,
+                                }}
+                            >
+                                <ChartAxis tickCount={3} />
+                                <ChartAxis
+                                    dependentAxis
+                                    showGrid
+                                    label={`interval: ${props.days} day(s) ${props.hours} hour(s)`}
+                                />
+                                <ChartGroup>{jobChartLines}</ChartGroup>
+                            </Chart>
+                        </div>
+                    </CardBody>
+                </Card>
+            </FlexItem>
+        );
+    }
+
+    return (
+        <>
+            <Card>
+                <CardBody>
+                    <Flex>
+                        {getLineChart(
+                            Object.keys(data.jobs),
+                            data.jobs,
+                            "Number of processed jobs",
+                        )}
+                        {getLineChart(
+                            ["sync_release_runs"],
+                            data.jobs,
+                            "Number of synced releases",
+                        )}
+                        {getLineChart(
+                            ["active_projects"],
+                            data,
+                            "Number of active projects",
+                        )}
+                        {getLineChart(
+                            Object.keys(data.events),
+                            data.events,
+                            "Number of processed events",
+                        )}
+                    </Flex>
+                </CardBody>
+            </Card>
+        </>
+    );
+};
+
+export { UsageInterval };

--- a/frontend/src/app/Usage/UsageInterval.tsx
+++ b/frontend/src/app/Usage/UsageInterval.tsx
@@ -13,6 +13,7 @@ import {
     ChartLine,
     createContainer,
     ChartLegendTooltip,
+    ChartThemeColor,
 } from "@patternfly/react-charts";
 
 import { ErrorConnection } from "../Errors/ErrorConnection";
@@ -124,6 +125,7 @@ const UsageInterval: React.FC<UsageIntervalProps> = (props) => {
                                 legendOrientation="vertical"
                                 legendPosition="right"
                                 minDomain={{ y: 0 }}
+                                themeColor={ChartThemeColor.multiUnordered}
                                 padding={{
                                     bottom: 50,
                                     left: 0, // Adjusted to accommodate axis label

--- a/packit_dashboard/api/routes.py
+++ b/packit_dashboard/api/routes.py
@@ -3,16 +3,19 @@
 
 import os
 from datetime import datetime, timedelta
+from logging import getLogger
 from pathlib import Path
 from typing import Union
 
 from cachetools.func import ttl_cache
-from flask import Blueprint, request, escape, render_template
+from flask import Blueprint, request, escape, render_template, current_app
 from flask_cors import CORS
 
 import packit_dashboard
 from packit_dashboard.config import API_URL
 from packit_dashboard.utils import make_response
+
+logger = getLogger("packit_dashboard")
 
 api = Blueprint(
     "api",
@@ -98,6 +101,7 @@ def _get_usage_data_from_packit_api(usage_from=None, usage_to=None, top=5):
         url += f"&from={usage_from}"
     if usage_to:
         url += f"&to={usage_to}"
+    current_app.logger.debug(f"Calling usage endpoint: {url}")
     return make_response(url)
 
 


### PR DESCRIPTION
This PR adds a new group of charts showing the usage trends.

The implementation follows the same workflow as with the existing usage charts:
* The data for the charts are collected, processed and cached on the backend.
* Frontend loads the data from the backend API.

The implementation can be improved a lot but I am worried I would never propose it otherwise..;)

Ideally, the usage queries should be moved to service and optimised. It takes a while to load it but it's probably fine since regular people don't check it on a daily basis. And if someone needs the data, the delay is not an issue.


The parameters for each view can be tweaked but this is what I would start with:

* Past year (= weekly for the last 52 weeks)
![Screenshot from 2023-09-03 12-38-34](https://github.com/packit/dashboard/assets/20214043/30b5e8ca-c705-4b75-9651-c3e42c3462d2)
* Past month (= daily for the last 30 days)
![Screenshot from 2023-09-03 12-38-40](https://github.com/packit/dashboard/assets/20214043/1b57f852-f318-452e-87be-1c9b2e7bb247)
* Past week (= daily for the last 7 days)
![Screenshot from 2023-09-03 12-38-46](https://github.com/packit/dashboard/assets/20214043/e00cfed5-17ec-4558-a7fe-be0032343dcc)
* Past day (= hourly for the last 24 hours)
![Screenshot from 2023-09-03 12-39-05](https://github.com/packit/dashboard/assets/20214043/aa26a35e-90ce-4f94-8735-e1b20d226224)

---

RELEASE NOTES BEGIN
There is a new group of charts https://dashboard.packit.dev/usage showing the trends.
RELEASE NOTES END
