### PR TITLE
Add usage trend charts for project count

### DIFF
--- a/frontend/src/app/Usage/UsageInterval.tsx
+++ b/frontend/src/app/Usage/UsageInterval.tsx
@@ -161,9 +161,21 @@ const UsageInterval: React.FC<UsageIntervalProps> = (props) => {
                             "Number of processed jobs",
                         )}
                         {getLineChart(
+                            Object.keys(data.jobs_project_count).filter(
+                                (obj) => obj !== "sync_release_runs",
+                            ),
+                            data.jobs_project_count,
+                            "Number of projects with processed jobs of this type",
+                        )}
+                        {getLineChart(
                             ["sync_release_runs"],
                             data.jobs,
                             "Number of synced releases",
+                        )}
+                        {getLineChart(
+                            ["sync_release_runs"],
+                            data.jobs_project_count,
+                            "Number of projects with synced releases",
                         )}
                         {getLineChart(
                             ["active_projects"],


### PR DESCRIPTION
This adds two new charts to show the usage of jobs for the number of unique projects.


![image](https://github.com/packit/dashboard/assets/20214043/55f4f1c1-ddb7-429a-b134-8ac6c469cf7e)




RELEASE NOTES BEGIN
Two new charts are available at https://dashboard.packit.dev/usage to show the trends based on the number of active projects.
RELEASE NOTES END
