### PR TITLE
chore: install yarn deps in production mode

### DIFF
--- a/files/ansible/recipe.yaml
+++ b/files/ansible/recipe.yaml
@@ -15,7 +15,7 @@
     - name: install node modules
       command:
         chdir: "{{ packit_dashboard_path }}"
-        cmd: yarn install
+        cmd: yarn install --production --frozen-lockfile
 
     - name: bundle javascript
       command:


### PR DESCRIPTION
From the yarn docs:

> Yarn will not install any package listed in `devDependencies` if the
> `NODE_ENV` environment variable is set to `production`. Use this flag
> to instruct Yarn to ignore `NODE_ENV` and take its production-or-not
> status from this flag instead.

This should ensure that no development dependencies, such as `surge`, are installed at all in the image that we use for deployments.

Yet another follow-up to the vulnerability report for the MP+ deployment.