### PR TITLE
fix: projects not fetching right API

### DIFF
--- a/frontend/src/app/Projects/ProjectsList.tsx
+++ b/frontend/src/app/Projects/ProjectsList.tsx
@@ -75,7 +75,9 @@ const ProjectsList: React.FC<ProjectsListProps> = (props) => {
     // Fetch data from dashboard backend (or if we want, directly from the API)
     const fetchData = ({ pageParam = 1 }): Promise<Project> =>
         fetch(
-            `${import.meta.env.VITE_API_URL}/projects?page=${pageParam}`,
+            `${import.meta.env.VITE_API_URL}/projects${
+                props.forge ? "/" + props.forge : ""
+            }${props.namespace ? "/" + props.namespace : ""}?page=${pageParam}`,
         ).then((response) => response.json());
 
     const { isInitialLoading, isError, fetchNextPage, data } = useInfiniteQuery(

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -112,7 +112,7 @@ const routes: RouteObject[] = [
                 },
             },
             {
-                path: "/projects/:forge/",
+                path: "/projects/:forge",
                 element: <Forge />,
             },
             {


### PR DESCRIPTION
The underlying `ProjectsList` component didn't take care of namespaces or forges so just fixing that fixed the issue

There was also a trailing forwardslash in the routing which was incorrect

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes
#321

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Fix projects with forge and with/without namespace not showing right results
RELEASE NOTES END
