### PR TITLE
refactor: Move sidebar items around

### DIFF
--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -39,10 +39,20 @@ const routes: RouteObject[] = [
                 },
             },
             {
+                element: <Projects />,
+                path: "/projects",
+                handle: {
+                    divider: true,
+                    label: "Projects",
+                    category: "Dashboards",
+                },
+            },
+            {
                 Component: Jobs,
                 id: "jobs",
                 path: "/jobs",
                 handle: {
+                    category: "Dashboards",
                     label: "Jobs",
                 },
                 children: [
@@ -101,14 +111,8 @@ const routes: RouteObject[] = [
                 element: <Pipelines />,
                 path: "/pipelines",
                 handle: {
+                    category: "Dashboards",
                     label: "Pipelines",
-                },
-            },
-            {
-                element: <Projects />,
-                path: "/projects",
-                handle: {
-                    label: "Projects",
                 },
             },
             {


### PR DESCRIPTION
This will prepare us for more granular interaction with project selection in the future. For now until that is implemented we have this to go with.

![image](https://github.com/packit/dashboard/assets/6598829/3cd2dea2-7968-4c3d-8958-edd938a7c1d9)


TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to
#306 

Merge before/after

---

RELEASE NOTES BEGIN
Move sidebar routes around and categorize them
RELEASE NOTES END
