### PR TITLE
feat: Router link for SRPM build link

### DIFF
--- a/frontend/src/app/Results/ResultsPageCoprDetails.tsx
+++ b/frontend/src/app/Results/ResultsPageCoprDetails.tsx
@@ -12,6 +12,8 @@ import { getCommitLink } from "../utils/forgeUrls";
 import { CoprResult } from "./ResultsPageCopr";
 import React from "react";
 import { StatusLabel } from "../StatusLabel/StatusLabel";
+import { Link, NavLink } from "react-router-dom";
+import { LabelLink } from "../utils/LabelLink";
 
 export interface ResultsPageCoprDetailsProps {
     data: CoprResult;
@@ -30,9 +32,11 @@ export const ResultsPageCoprDetails: React.FC<ResultsPageCoprDetailsProps> = ({
             <DescriptionListGroup>
                 <DescriptionListTerm>SRPM Build</DescriptionListTerm>
                 <DescriptionListDescription>
-                    <Label href={`/results/srpm-builds/${data.srpm_build_id}`}>
+                    <LabelLink
+                        to={`/results/srpm-builds/${data.srpm_build_id}`}
+                    >
                         Details
-                    </Label>
+                    </LabelLink>
                 </DescriptionListDescription>
                 <DescriptionListTerm>Copr build</DescriptionListTerm>
                 <DescriptionListDescription>

--- a/frontend/src/app/utils/LabelLink.tsx
+++ b/frontend/src/app/utils/LabelLink.tsx
@@ -1,0 +1,26 @@
+import { Label } from "@patternfly/react-core";
+import React from "react";
+import { Link } from "react-router-dom";
+
+export interface LabelLinkProps {
+    to: string;
+    children?: React.ReactNode;
+    className?: string;
+}
+
+export const LabelLink: React.FC<LabelLinkProps> = ({
+    to,
+    className = "",
+    children = null,
+}) => (
+    <Label
+        className={className}
+        render={({ className, content, componentRef }) => (
+            <Link to={to} className={className} ref={componentRef}>
+                {content}
+            </Link>
+        )}
+    >
+        {children}
+    </Label>
+);


### PR DESCRIPTION
Within Copr Build results there is an SRPM Build link that is within the website. To make it seamless with loading we should use NavLink. This changes that

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Improve SRPM link within Copr Build results
RELEASE NOTES END
