### PR TITLE
fix: External link in TriggerInfo to show link

### DIFF
--- a/frontend/src/app/Trigger/TriggerInfo.tsx
+++ b/frontend/src/app/Trigger/TriggerInfo.tsx
@@ -233,8 +233,11 @@ interface WebUrlIconProps {
 }
 
 const WebUrlIcon: React.FC<WebUrlIconProps> = (props) => {
-    const handleClick = () => window.open(props.link, "_blank");
-    return <ExternalLinkAltIcon onClick={handleClick} />;
+    return (
+        <a href={props.link} rel="noreferrer" target="_blank">
+            <ExternalLinkAltIcon />
+        </a>
+    );
 };
 
 export { TriggerInfo };


### PR DESCRIPTION
Before this change it opened the link in a new page/tab but did not
show the URL it is going to, so you could not copy the link or see that
it is a link

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Show the external links correctly in project view
RELEASE NOTES END
