### PR TITLE
fix: correct labels for Projects in small viewport

### DIFF
--- a/frontend/src/app/Projects/ProjectsList.tsx
+++ b/frontend/src/app/Projects/ProjectsList.tsx
@@ -61,6 +61,8 @@ interface ProjectsListProps {
 const columnNames = {
     name: "Repositories",
     branches: "Branches",
+    issues: "Issues",
+    releases: "Releases",
     prs: "Pull requests",
     workspaces: "Workspaces",
     lastCommit: "Last commit",
@@ -144,34 +146,46 @@ const ProjectsList: React.FC<ProjectsListProps> = (props) => {
                                     dataLabel={columnNames.branches}
                                     // compoundExpand={compoundExpandParams(repo, 'branches', rowIndex, 1)}
                                 >
-                                    <CodeBranchIcon key="icon" />{" "}
-                                    {project.branches_handled}
+                                    <span>
+                                        <CodeBranchIcon key="icon" />
+                                        &nbsp;
+                                        {project.branches_handled}
+                                    </span>
                                 </Td>
                                 <Td
                                     width={10}
-                                    dataLabel={columnNames.branches}
+                                    dataLabel={columnNames.issues}
                                     // compoundExpand={compoundExpandParams(repo, 'branches', rowIndex, 1)}
                                 >
-                                    <SecurityIcon key="icon" />{" "}
-                                    {project.issues_handled}
+                                    <span>
+                                        <SecurityIcon key="icon" />
+                                        &nbsp;
+                                        {project.issues_handled}
+                                    </span>
                                 </Td>
                                 <Td
                                     width={10}
-                                    dataLabel={columnNames.branches}
+                                    dataLabel={columnNames.releases}
                                     // compoundExpand={compoundExpandParams(repo, 'branches', rowIndex, 1)}
                                 >
-                                    <BuildIcon key="icon" />{" "}
-                                    {project.releases_handled}
+                                    <span>
+                                        <BuildIcon key="icon" />
+                                        &nbsp;
+                                        {project.releases_handled}
+                                    </span>
                                 </Td>
                                 <Td
                                     width={15}
-                                    dataLabel={columnNames.branches}
+                                    dataLabel={columnNames.prs}
                                     // compoundExpand={compoundExpandParams(repo, 'branches', rowIndex, 1)}
                                 >
-                                    <BlueprintIcon key="icon" />{" "}
-                                    {project.prs_handled}
+                                    <span>
+                                        <BlueprintIcon key="icon" />
+                                        &nbsp;
+                                        {project.prs_handled}
+                                    </span>
                                 </Td>
-                                <Td dataLabel={columnNames.branches}>
+                                <Td dataLabel="External">
                                     <a
                                         href={project.project_url}
                                         target="_blank"


### PR DESCRIPTION
Within the Projects view the rows when in a small viewport does not
display the correct labels. This is now corrected

Before:
![before](https://github.com/packit/dashboard/assets/6598829/68bf72c0-3c3a-42a8-bdf2-c7bd12d4ebb5)

After:
![after](https://github.com/packit/dashboard/assets/6598829/7e0a1dba-b552-4c60-ad4d-bf4810422377)


TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Address incorrect label and label format in Projects view
RELEASE NOTES END
