### PR TITLE
fix: Ghost data when switching tabs in Jobs

### DIFF
--- a/frontend/src/app/Jobs/CoprBuildsTable.tsx
+++ b/frontend/src/app/Jobs/CoprBuildsTable.tsx
@@ -94,7 +94,6 @@ const CoprBuildsTable = () => {
     const { isInitialLoading, isError, fetchNextPage, data, isFetching } =
         useInfiniteQuery(["copr"], fetchData, {
             getNextPageParam: (_, allPages) => allPages.length + 1,
-            keepPreviousData: true,
         });
 
     // Convert fetched json into row format that the table can read

--- a/frontend/src/app/Jobs/KojiBuildsTable.tsx
+++ b/frontend/src/app/Jobs/KojiBuildsTable.tsx
@@ -59,7 +59,6 @@ const KojiBuildsTable = () => {
     const { isInitialLoading, isError, fetchNextPage, data, isFetching } =
         useInfiniteQuery(["koji"], fetchData, {
             getNextPageParam: (_, allPages) => allPages.length + 1,
-            keepPreviousData: true,
         });
 
     // Convert fetched json into row format that the table can read

--- a/frontend/src/app/Jobs/SRPMBuildsTable.tsx
+++ b/frontend/src/app/Jobs/SRPMBuildsTable.tsx
@@ -55,7 +55,6 @@ const SRPMBuildsTable = () => {
     const { isInitialLoading, isError, fetchNextPage, data, isFetching } =
         useInfiniteQuery(["srpm"], fetchData, {
             getNextPageParam: (_, allPages) => allPages.length + 1,
-            keepPreviousData: true,
         });
 
     // Convert fetched json into row format that the table can read

--- a/frontend/src/app/Jobs/SyncReleaseStatuses.tsx
+++ b/frontend/src/app/Jobs/SyncReleaseStatuses.tsx
@@ -90,7 +90,6 @@ const SyncReleaseTable: React.FC<SyncReleaseTableProps> = ({ job }) => {
     const { isInitialLoading, isError, fetchNextPage, data, isFetching } =
         useInfiniteQuery([job], fetchData, {
             getNextPageParam: (_, allPages) => allPages.length + 1,
-            keepPreviousData: true,
         });
 
     // Convert fetched json into row format that the table can read

--- a/frontend/src/app/Jobs/TestingFarmResultsTable.tsx
+++ b/frontend/src/app/Jobs/TestingFarmResultsTable.tsx
@@ -53,7 +53,6 @@ const TestingFarmResultsTable = () => {
     const { isInitialLoading, isError, fetchNextPage, data, isFetching } =
         useInfiniteQuery(["copr"], fetchData, {
             getNextPageParam: (_, allPages) => allPages.length + 1,
-            keepPreviousData: true,
         });
 
     function jsonToRow(test_results: TestingFarmResult[]) {


### PR DESCRIPTION
Within Jobs currently when you switch between different tabs it will show the data from the previous tab until data has loaded, this can be confusing as it can at times take a long time to load

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Fix leftover data when loading within Jobs tab
RELEASE NOTES END
