### PR TITLE
fix: fullscreen logs not using the whole height

### DIFF
--- a/frontend/src/app/Results/ResultsPageSyncReleaseRuns.tsx
+++ b/frontend/src/app/Results/ResultsPageSyncReleaseRuns.tsx
@@ -153,7 +153,7 @@ const ResultsPageSyncReleaseRuns: React.FC<ResultsPageSyncReleaseRunsProps> = ({
                         isTextWrapped={isTextWrapped}
                         hasLineNumbers={isLineNumbersShown}
                         theme="dark"
-                        // height={isFullScreen ? "100%" : 600}
+                        height={isFullScreen ? "100%" : 600}
                         data={
                             data.logs ? data.logs : "Log is not available yet."
                         }


### PR DESCRIPTION
There was a leftover comment that should have been uncommented

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Fix logs not utilizing the whole height in fullscreen mode
RELEASE NOTES END
