### PR TITLE
Show downstream Koji builds

### DIFF
--- a/frontend/src/app/Jobs/Jobs.tsx
+++ b/frontend/src/app/Jobs/Jobs.tsx
@@ -95,6 +95,16 @@ const Jobs = () => {
                                     Pull From Upstreams
                                 </NavLink>
                             </NavItem>
+                            <NavItem
+                                isActive={
+                                    currentMatch?.id ===
+                                    "downstream-koji-builds"
+                                }
+                            >
+                                <NavLink to={"downstream-koji-builds"}>
+                                    Downstream Koji Builds
+                                </NavLink>
+                            </NavItem>
                         </NavList>
                     </Nav>
                 </PageNavigation>

--- a/frontend/src/app/Jobs/KojiBuildsTable.tsx
+++ b/frontend/src/app/Jobs/KojiBuildsTable.tsx
@@ -18,12 +18,12 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 
 export interface KojiBuild {
     packit_id: number;
-    build_id: string;
+    task_id: string;
     status: string; // TODO(SpyTec): Probably an enum right? Change to be one if so
     build_submitted_time: number;
     chroot: string;
     web_url: string;
-    build_logs_url: string;
+    build_logs_urls: string;
     // TODO(SpyTec): change interface depending on status of pr_id or branch_item.
     // They seem to be mutually exclusive so can be sure one is null and other is string
     pr_id: number | null;
@@ -33,8 +33,10 @@ export interface KojiBuild {
     repo_namespace: string;
     repo_name: string;
 }
-
-const KojiBuildsTable = () => {
+interface KojiBuildTableProps {
+    scratch: "true" | "false";
+}
+const KojiBuildsTable: React.FC<KojiBuildTableProps> = ({ scratch }) => {
     // Headings
     const columns = [
         {
@@ -51,7 +53,7 @@ const KojiBuildsTable = () => {
         fetch(
             `${
                 import.meta.env.VITE_API_URL
-            }/koji-builds?page=${pageParam}&per_page=20`,
+            }/koji-builds?scratch=${scratch}&page=${pageParam}&per_page=20`,
         )
             .then((response) => response.json())
             .then((data) => jsonToRow(data));
@@ -102,7 +104,7 @@ const KojiBuildsTable = () => {
                                     target="_blank"
                                     rel="noreferrer"
                                 >
-                                    {koji_build.build_id}
+                                    {koji_build.task_id}
                                 </a>
                             </strong>
                         ),

--- a/frontend/src/app/Results/ResultsPageKoji.tsx
+++ b/frontend/src/app/Results/ResultsPageKoji.tsx
@@ -13,7 +13,8 @@ import {
     DescriptionListGroup,
     DescriptionListTerm,
 } from "@patternfly/react-core";
-
+import { TableHeader, TableBody } from "@patternfly/react-table/deprecated";
+import { Table, Tbody, Td, Th, Thead, Tr } from "@patternfly/react-table";
 import { ErrorConnection } from "../Errors/ErrorConnection";
 import { Preloader } from "../Preloader/Preloader";
 import { TriggerLink } from "../Trigger/TriggerLink";
@@ -26,7 +27,8 @@ import { useQuery } from "@tanstack/react-query";
 import { SHACopy } from "../utils/SHACopy";
 
 interface KojiBuild {
-    build_id: string;
+    scratch: boolean;
+    task_id: string;
     status: string;
     chroot: string;
     build_start_time: number;
@@ -34,7 +36,7 @@ interface KojiBuild {
     build_submitted_time: number;
     commit_sha: string;
     web_url: string;
-    build_logs_url: string;
+    build_logs_urls: string;
     srpm_build_id: number;
     run_ids: number[];
     repo_namespace: string;
@@ -115,16 +117,20 @@ const ResultsPageKoji = () => {
                             }}
                         >
                             <DescriptionListGroup>
-                                <DescriptionListTerm>
-                                    SRPM Build
-                                </DescriptionListTerm>
-                                <DescriptionListDescription>
-                                    <Label
-                                        href={`/results/srpm-builds/${data.srpm_build_id}`}
-                                    >
-                                        Details
-                                    </Label>
-                                </DescriptionListDescription>
+                                {data.srpm_build_id ? (
+                                    <>
+                                        <DescriptionListTerm>
+                                            SRPM Build
+                                        </DescriptionListTerm>
+                                        <DescriptionListDescription>
+                                            <Label
+                                                href={`/results/srpm-builds/${data.srpm_build_id}`}
+                                            >
+                                                Details
+                                            </Label>
+                                        </DescriptionListDescription>
+                                    </>
+                                ) : null}
                                 <DescriptionListTerm>
                                     Koji Build
                                 </DescriptionListTerm>
@@ -134,15 +140,38 @@ const ResultsPageKoji = () => {
                                         status={data.status}
                                         link={data.web_url}
                                     />{" "}
-                                    (
-                                    <a
-                                        href={data.build_logs_url}
-                                        rel="noreferrer"
-                                        target={"_blank"}
-                                    >
-                                        Logs
-                                    </a>
-                                    )
+                                    ({data.scratch ? "scratch" : "production"})
+                                </DescriptionListDescription>
+                                <DescriptionListTerm>
+                                    Build logs
+                                </DescriptionListTerm>
+                                <DescriptionListDescription>
+                                    {data.build_logs_urls !== null &&
+                                    Object.keys(data.build_logs_urls).length !==
+                                        0 ? (
+                                        <Table variant="compact">
+                                            <Tbody>
+                                                {data.build_logs_urls
+                                                    ? Object.entries(
+                                                          data.build_logs_urls,
+                                                      ).map(([arch, url]) => (
+                                                          <Tr key={arch}>
+                                                              <Td
+                                                                  role="cell"
+                                                                  data-label="Build log"
+                                                              >
+                                                                  <a href={url}>
+                                                                      {arch}
+                                                                  </a>
+                                                              </Td>
+                                                          </Tr>
+                                                      ))
+                                                    : null}
+                                            </Tbody>
+                                        </Table>
+                                    ) : (
+                                        <span>not provided</span>
+                                    )}
                                 </DescriptionListDescription>
                             </DescriptionListGroup>
                             <DescriptionListGroup>

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -66,7 +66,7 @@ const routes: RouteObject[] = [
                         },
                     },
                     {
-                        element: <KojiBuildsTable />,
+                        element: <KojiBuildsTable scratch="true" />,
                         id: "koji-builds",
                         path: "koji-builds",
                         handle: {
@@ -103,6 +103,14 @@ const routes: RouteObject[] = [
                         path: "pull-from-upstreams",
                         handle: {
                             label: "Pull From Upstreams",
+                        },
+                    },
+                    {
+                        element: <KojiBuildsTable scratch="false" />,
+                        id: "downstream-koji-builds",
+                        path: "downstream-koji-builds",
+                        handle: {
+                            label: "Downstream (production) Koji builds",
                         },
                     },
                 ],


### PR DESCRIPTION
Create a separate table for downstream Koji builds and adjust the result view to the API changes.

Fixes #214



![Snímka obrazovky z 2023-11-08 11-04-46](https://github.com/packit/dashboard/assets/49026743/6d3d2a03-1be2-4eda-b1e6-241a8507d85b)

![Snímka obrazovky z 2023-11-09 14-55-15](https://github.com/packit/dashboard/assets/49026743/74f7609a-b992-45ae-9aa6-b5222a73bbc4)


---
RELEASE NOTES BEGIN
Downstream Koji builds are now shown in a separate table in `/jobs/downstream-koji-builds`.
RELEASE NOTES END
