### PR TITLE
refactor: detach page nav from content

### DIFF
--- a/frontend/src/app/Jobs/Jobs.tsx
+++ b/frontend/src/app/Jobs/Jobs.tsx
@@ -43,71 +43,58 @@ const Jobs = () => {
                     <Text component="p">List of jobs by Packit Service</Text>
                 </TextContent>
             </PageSection>
+            <PageNavigation>
+                <Nav aria-label="Job types" variant="tertiary">
+                    <NavList>
+                        <NavItem isActive={currentMatch?.id === "copr-builds"}>
+                            <NavLink to={"copr-builds"}>Copr Builds</NavLink>
+                        </NavItem>
+                        <NavItem isActive={currentMatch?.id === "koji-builds"}>
+                            <NavLink to={"koji-builds"}>
+                                Upstream Koji Builds
+                            </NavLink>
+                        </NavItem>
+                        <NavItem isActive={currentMatch?.id === "srpm-builds"}>
+                            <NavLink to={"srpm-builds"}>SRPM Builds</NavLink>
+                        </NavItem>
+                        <NavItem
+                            isActive={currentMatch?.id === "testing-farm-runs"}
+                        >
+                            <NavLink to={"testing-farm-runs"}>
+                                Testing Farm Runs
+                            </NavLink>
+                        </NavItem>
+                        <NavItem
+                            isActive={
+                                currentMatch?.id === "propose-downstreams"
+                            }
+                        >
+                            <NavLink to={"propose-downstreams"}>
+                                Propose Downstreams
+                            </NavLink>
+                        </NavItem>
+                        <NavItem
+                            isActive={
+                                currentMatch?.id === "pull-from-upstreams"
+                            }
+                        >
+                            <NavLink to={"pull-from-upstreams"}>
+                                Pull From Upstreams
+                            </NavLink>
+                        </NavItem>
+                        <NavItem
+                            isActive={
+                                currentMatch?.id === "downstream-koji-builds"
+                            }
+                        >
+                            <NavLink to={"downstream-koji-builds"}>
+                                Downstream Koji Builds
+                            </NavLink>
+                        </NavItem>
+                    </NavList>
+                </Nav>
+            </PageNavigation>
             <PageSection>
-                <PageNavigation>
-                    <Nav aria-label="Job types" variant="tertiary">
-                        <NavList>
-                            <NavItem
-                                isActive={currentMatch?.id === "copr-builds"}
-                            >
-                                <NavLink to={"copr-builds"}>
-                                    Copr Builds
-                                </NavLink>
-                            </NavItem>
-                            <NavItem
-                                isActive={currentMatch?.id === "koji-builds"}
-                            >
-                                <NavLink to={"koji-builds"}>
-                                    Upstream Koji Builds
-                                </NavLink>
-                            </NavItem>
-                            <NavItem
-                                isActive={currentMatch?.id === "srpm-builds"}
-                            >
-                                <NavLink to={"srpm-builds"}>
-                                    SRPM Builds
-                                </NavLink>
-                            </NavItem>
-                            <NavItem
-                                isActive={
-                                    currentMatch?.id === "testing-farm-runs"
-                                }
-                            >
-                                <NavLink to={"testing-farm-runs"}>
-                                    Testing Farm Runs
-                                </NavLink>
-                            </NavItem>
-                            <NavItem
-                                isActive={
-                                    currentMatch?.id === "propose-downstreams"
-                                }
-                            >
-                                <NavLink to={"propose-downstreams"}>
-                                    Propose Downstreams
-                                </NavLink>
-                            </NavItem>
-                            <NavItem
-                                isActive={
-                                    currentMatch?.id === "pull-from-upstreams"
-                                }
-                            >
-                                <NavLink to={"pull-from-upstreams"}>
-                                    Pull From Upstreams
-                                </NavLink>
-                            </NavItem>
-                            <NavItem
-                                isActive={
-                                    currentMatch?.id ===
-                                    "downstream-koji-builds"
-                                }
-                            >
-                                <NavLink to={"downstream-koji-builds"}>
-                                    Downstream Koji Builds
-                                </NavLink>
-                            </NavItem>
-                        </NavList>
-                    </Nav>
-                </PageNavigation>
                 <Outlet />
             </PageSection>
         </PageGroup>


### PR DESCRIPTION
Ignore table contents from image as I have other files changed locally

![image](https://github.com/packit/dashboard/assets/6598829/eb1d93f7-e0ed-459a-a4c2-c6d75603a1ee)

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
Improve UX of Job tabs by detaching from tables
RELEASE NOTES END
