### PR TITLE
Onboarding charts

### DIFF
--- a/frontend/src/app/Usage/UsageInterval.tsx
+++ b/frontend/src/app/Usage/UsageInterval.tsx
@@ -2,9 +2,12 @@ import {
     PageSection,
     Card,
     CardBody,
+    CardTitle,
     Title,
     Flex,
     FlexItem,
+    LabelGroup,
+    Label,
 } from "@patternfly/react-core";
 import {
     Chart,
@@ -151,6 +154,24 @@ const UsageInterval: React.FC<UsageIntervalProps> = (props) => {
     return (
         <>
             <Card>
+                <CardTitle>Project activity</CardTitle>
+                <CardBody>
+                    <Flex>
+                        {getLineChart(
+                            ["active_projects"],
+                            data,
+                            "Number of active projects",
+                        )}
+                        {getLineChart(
+                            Object.keys(data.events),
+                            data.events,
+                            "Number of processed events",
+                        )}
+                    </Flex>
+                </CardBody>
+            </Card>
+            <Card>
+                <CardTitle>Processed jobs</CardTitle>
                 <CardBody>
                     <Flex>
                         {getLineChart(
@@ -161,6 +182,18 @@ const UsageInterval: React.FC<UsageIntervalProps> = (props) => {
                             "Number of processed jobs",
                         )}
                         {getLineChart(
+                            ["sync_release_runs"],
+                            data.jobs,
+                            "Number of synced releases",
+                        )}
+                    </Flex>
+                </CardBody>
+            </Card>
+            <Card>
+                <CardTitle>Active projects</CardTitle>
+                <CardBody>
+                    <Flex>
+                        {getLineChart(
                             Object.keys(data.jobs_project_count).filter(
                                 (obj) => obj !== "sync_release_runs",
                             ),
@@ -169,23 +202,25 @@ const UsageInterval: React.FC<UsageIntervalProps> = (props) => {
                         )}
                         {getLineChart(
                             ["sync_release_runs"],
-                            data.jobs,
-                            "Number of synced releases",
-                        )}
-                        {getLineChart(
-                            ["sync_release_runs"],
                             data.jobs_project_count,
                             "Number of projects with synced releases",
                         )}
+                    </Flex>
+                </CardBody>
+            </Card>
+            <Card>
+                <CardTitle>Onboarded projects</CardTitle>
+                <CardBody>
+                    <Flex>
                         {getLineChart(
-                            ["active_projects"],
-                            data,
-                            "Number of active projects",
+                            Object.keys(data.jobs_project_cumulative_count),
+                            data.jobs_project_cumulative_count,
+                            "Cumulative number of projects with at least a single job run",
                         )}
                         {getLineChart(
-                            Object.keys(data.events),
-                            data.events,
-                            "Number of processed events",
+                            ["active_projects_cumulative"],
+                            data,
+                            "Active projects",
                         )}
                     </Flex>
                 </CardBody>

--- a/frontend/src/app/Usage/UsageInterval.tsx
+++ b/frontend/src/app/Usage/UsageInterval.tsx
@@ -23,6 +23,7 @@ import { ErrorConnection } from "../Errors/ErrorConnection";
 import { Preloader } from "../Preloader/Preloader";
 import { useQuery } from "@tanstack/react-query";
 import { UsageListData } from "./UsageListData";
+import { ForgeIcon } from "../Forge/ForgeIcon";
 
 const fetchDataByGranularity = (granularity: UsageIntervalProps) =>
     fetch(
@@ -151,6 +152,33 @@ const UsageInterval: React.FC<UsageIntervalProps> = (props) => {
         );
     }
 
+    function getListOfNewProjects(projects, categoryName, color) {
+        return (
+            <LabelGroup categoryName={getReadableName(categoryName) + ":"}>
+                {projects.map((project) => (
+                    <Label
+                        variant="outline"
+                        color="blue"
+                        href={project}
+                        icon={<ForgeIcon url={project} />}
+                    >
+                        {project.replace("https://", "")}
+                    </Label>
+                ))}
+            </LabelGroup>
+        );
+    }
+
+    function getListOfNewProjectsForJobs(projectsForJobs) {
+        return (
+            <>
+                {Object.keys(projectsForJobs).map((job) => (
+                    <>{getListOfNewProjects(projectsForJobs[job], job)}</>
+                ))}
+            </>
+        );
+    }
+
     return (
         <>
             <Card>
@@ -222,6 +250,20 @@ const UsageInterval: React.FC<UsageIntervalProps> = (props) => {
                             data,
                             "Active projects",
                         )}
+                        <FlexItem>
+                            <Card>
+                                <CardTitle>New projects:</CardTitle>
+                                <CardBody>
+                                    {getListOfNewProjects(
+                                        data.onboarded_projects,
+                                        "New setup",
+                                    )}
+                                    {getListOfNewProjectsForJobs(
+                                        data.onboarded_projects_per_job,
+                                    )}
+                                </CardBody>
+                            </Card>
+                        </FlexItem>
                     </Flex>
                 </CardBody>
             </Card>


### PR DESCRIPTION
* Add info about onboarded projects to the backend API.
* Add new cumulative usage charts to show the state of onboarding.
* Show the newly onboarded projects. Both globally or once the project starts to use a new job.

Fixes: packit/packit-service#2232


Some screenshots using prod data:

## Past month
![image](https://github.com/packit/dashboard/assets/20214043/e565ecf0-8d0a-435a-afe1-a6c4e7e2ea56)

## Past year
![image](https://github.com/packit/dashboard/assets/20214043/04da0630-5ba4-45bd-8421-1b56cf48fdc4)


---

RELEASE NOTES BEGIN
There are new usage charts at https://dashboard.packit.dev/usage showing the status of new projects' onboarding.
RELEASE NOTES END
