### PR TITLE
Packit usage charts simplification and packit goal

### DIFF
--- a/frontend/src/app/Usage/UsageList.tsx
+++ b/frontend/src/app/Usage/UsageList.tsx
@@ -7,7 +7,7 @@ import {
     Flex,
     FlexItem,
 } from "@patternfly/react-core";
-import { ChartDonut } from "@patternfly/react-charts";
+import { ChartDonut, ChartBullet } from "@patternfly/react-charts";
 
 import { ErrorConnection } from "../Errors/ErrorConnection";
 import { Preloader } from "../Preloader/Preloader";
@@ -221,6 +221,60 @@ const UsageList: React.FC<UsageListProps> = (props) => {
         );
     }
 
+    function getGoalProgress() {
+        if (props.what != "total") {
+            return <></>;
+        }
+        const goalDescription =
+            data.jobs.sync_release_runs.active_projects.toString() +
+            " projects (" +
+            (
+                (data.jobs.sync_release_runs.active_projects / 200) *
+                100
+            ).toString() +
+            "%)";
+        return (
+            <Card>
+                <CardTitle>Packit goal for Q4/2023</CardTitle>
+                <CardBody>
+                    <Flex>
+                        <Card>
+                            <CardTitle>
+                                Sync release used by 200 projects by the end of
+                                2023.
+                            </CardTitle>
+                            <CardBody>
+                                <ChartBullet
+                                    ariaDesc="Chart describing onboarding for release syncing"
+                                    ariaTitle="Chart describing onboarding for release syncing"
+                                    constrainToVisibleArea
+                                    labels={({ datum }) =>
+                                        `${datum.name}: ${datum.y}`
+                                    }
+                                    maxDomain={{ y: 200 }}
+                                    name="Chart describing onboarding for release syncing"
+                                    primarySegmentedMeasureData={[
+                                        {
+                                            name: "Onboarded projects",
+                                            y: data.jobs.sync_release_runs
+                                                .active_projects,
+                                        },
+                                    ]}
+                                    qualitativeRangeData={[
+                                        { name: "Q3 state", y: 124 },
+                                        { name: "Q4 goal", y: 200 },
+                                    ]}
+                                    height={150}
+                                    width={424}
+                                />
+                            </CardBody>
+                        </Card>
+                    </Flex>
+                </CardBody>
+            </Card>
+        );
+    }
+
     function getReadableJobName(job_name: string) {
         return job_name
             .toLowerCase()
@@ -263,6 +317,7 @@ const UsageList: React.FC<UsageListProps> = (props) => {
                     <Flex>{job_charts}</Flex>
                 </CardBody>
             </Card>
+            {getGoalProgress()}
         </>
     );
 };

--- a/frontend/src/app/Usage/UsageList.tsx
+++ b/frontend/src/app/Usage/UsageList.tsx
@@ -2,6 +2,7 @@ import {
     PageSection,
     Card,
     CardBody,
+    CardTitle,
     Title,
     Flex,
     FlexItem,
@@ -119,38 +120,69 @@ const UsageList: React.FC<UsageListProps> = (props) => {
         data_and_labels: ChartData,
         job_name: string,
         total_number: number,
+        active_project_number: number,
     ) {
         return (
             <FlexItem>
                 <Card>
+                    <CardTitle>{job_name}</CardTitle>
                     <CardBody>
-                        <ChartDonut
-                            ariaDesc={
-                                "Number of " +
-                                `${job_name}` +
-                                " triggered for top projects"
-                            }
-                            ariaTitle={
-                                "Number of " +
-                                `${job_name}` +
-                                " triggered for top projects"
-                            }
-                            constrainToVisibleArea={true}
-                            data={data_and_labels[0]}
-                            labels={({ datum }) => `${datum.x}: ${datum.y}`}
-                            legendData={data_and_labels[1]}
-                            legendOrientation="vertical"
-                            legendPosition="right"
-                            padding={{
-                                bottom: 20,
-                                left: 0,
-                                right: 350, // Adjusted to accommodate legend
-                                top: 20,
-                            }}
-                            subTitle={job_name}
-                            title={total_number.toString()}
-                            width={500}
-                        />
+                        <Flex>
+                            <FlexItem>
+                                <ChartDonut
+                                    ariaDesc={
+                                        "Number of " +
+                                        `${job_name}` +
+                                        " triggered for top projects"
+                                    }
+                                    ariaTitle={
+                                        "Number of " +
+                                        `${job_name}` +
+                                        " triggered for top projects"
+                                    }
+                                    constrainToVisibleArea
+                                    data={data_and_labels[0]}
+                                    labels={({ datum }) =>
+                                        `${datum.x}: ${datum.y}`
+                                    }
+                                    subTitle={job_name}
+                                    title={total_number.toString()}
+                                    width={200}
+                                    padding={{
+                                        bottom: 20,
+                                        left: 20,
+                                        right: 20,
+                                        top: 20,
+                                    }}
+                                />
+                            </FlexItem>
+                            <FlexItem>
+                                <ChartDonut
+                                    ariaDesc="Chart showing number of active projects"
+                                    ariaTitle="Chart showing number of active projects"
+                                    constrainToVisibleArea
+                                    data={[
+                                        {
+                                            x: "Active projects",
+                                            y:
+                                                active_project_number > 0
+                                                    ? 100
+                                                    : 0,
+                                        },
+                                    ]}
+                                    labels={({ datum }) => `${datum.x}`}
+                                    subTitle="Active projects"
+                                    title={active_project_number.toString()}
+                                    width={200}
+                                    padding={{
+                                        bottom: 20,
+                                        left: 20,
+                                        right: 20,
+                                        top: 20,
+                                    }}
+                                />
+                            </FlexItem>
+                        </Flex>
                     </CardBody>
                 </Card>
             </FlexItem>
@@ -175,13 +207,13 @@ const UsageList: React.FC<UsageListProps> = (props) => {
                             legendPosition="right"
                             padding={{
                                 bottom: 20,
-                                left: 0,
-                                right: 350, // Adjusted to accommodate legend
+                                left: 20,
+                                right: 250, // Adjusted to accommodate legend
                                 top: 20,
                             }}
                             subTitle={job_name}
                             title={data_and_labels_total_number[2].toString()}
-                            width={500}
+                            width={424}
                         />
                     </CardBody>
                 </Card>
@@ -219,6 +251,7 @@ const UsageList: React.FC<UsageListProps> = (props) => {
                 .replace("Tft", "TFT")
                 .replace("Srpm", "SRPM"),
             data.jobs[key].job_runs,
+            data.jobs[key].active_projects,
         ),
     );
 

--- a/frontend/src/app/Usage/UsageList.tsx
+++ b/frontend/src/app/Usage/UsageList.tsx
@@ -93,20 +93,21 @@ const UsageList: React.FC<UsageListProps> = (props) => {
     function getInstanceChartData(instances: {
         [key: string]: number;
     }): InstanceChartData {
-        const instances_to_chart_data = Object.keys(instances)
-            .filter((inst) => !inst.includes("fedoraproject.org"))
-            .map((key, i) => ({
+        const instances_to_chart_data = Object.keys(instances).map(
+            (key, i) => ({
                 x: `${key}`,
                 y: instances[key],
-            }));
-        const instances_to_chart_legend = Object.keys(instances)
-            .filter((inst) => !inst.includes("fedoraproject.org"))
-            .map((key, i) => ({
+            }),
+        );
+        const instances_to_chart_legend = Object.keys(instances).map(
+            (key, i) => ({
                 name: `${key}: ${instances[key]}`,
-            }));
-        const instances_to_chart_count = Object.keys(instances)
-            .filter((inst) => !inst.includes("fedoraproject.org"))
-            .reduce((a, v) => (a = a + instances[v]), 0);
+            }),
+        );
+        const instances_to_chart_count = Object.keys(instances).reduce(
+            (a, v) => (a = a + instances[v]),
+            0,
+        );
         return [
             instances_to_chart_data,
             instances_to_chart_legend,

--- a/frontend/src/app/Usage/UsageList.tsx
+++ b/frontend/src/app/Usage/UsageList.tsx
@@ -229,10 +229,6 @@ const UsageList: React.FC<UsageListProps> = (props) => {
             .join(" ");
     }
 
-    const all_projects_instance_chart = getInstanceChart(
-        getInstanceChartData(data.all_projects.instances),
-        "All projects",
-    );
     const active_projects_instance_chart = getInstanceChart(
         getInstanceChartData(data.active_projects.instances),
         "Active projects",
@@ -259,10 +255,7 @@ const UsageList: React.FC<UsageListProps> = (props) => {
         <>
             <Card>
                 <CardBody>
-                    <Flex>
-                        {all_projects_instance_chart}
-                        {active_projects_instance_chart}
-                    </Flex>
+                    <Flex>{active_projects_instance_chart}</Flex>
                 </CardBody>
             </Card>
             <Card>

--- a/frontend/src/app/Usage/UsageList.tsx
+++ b/frontend/src/app/Usage/UsageList.tsx
@@ -197,8 +197,8 @@ const UsageList: React.FC<UsageListProps> = (props) => {
                 <Card>
                     <CardBody>
                         <ChartDonut
-                            ariaDesc="Number of project on each instance"
-                            ariaTitle="Number of project on each instance"
+                            ariaDesc="Number of projects on each instance"
+                            ariaTitle="Number of projects on each instance"
                             constrainToVisibleArea={true}
                             data={data_and_labels_total_number[0]}
                             labels={({ datum }) => `${datum.x}: ${datum.y}`}

--- a/packit_dashboard/api/routes.py
+++ b/packit_dashboard/api/routes.py
@@ -111,11 +111,16 @@ def _get_usage_data_from_packit_api(usage_from=None, usage_to=None, top=5):
 
 
 def _get_past_usage_data_from_packit_api(usage_from=None, usage_to=None, top=5):
-    top_all = 100000  # we will filter later,
-    # but we need to get all to have a number of active projects
+    # Even though frontend expects only the first N (=5) to be present
+    # in the project lists, we need to get all to calculate the number
+    # of active projects.
+    # (This info will be added to the payload for frontend.)
+    # The original `top` argument will be used later
+    # to get the expected number of projects in the response.
+    top_all_project = 100000
 
     raw_result = _get_usage_data_from_packit_api(
-        usage_from=usage_from, usage_to=usage_to, top=top_all
+        usage_from=usage_from, usage_to=usage_to, top=top_all_project
     ).json
     return {
         "active_projects": raw_result["active_projects"],


### PR DESCRIPTION
* Show the number of active projects in usage charts instead of the legend for the top project that started to be less important and hard to fit into the page.
* Remove chart of all projects since it's independent to the time span.
* Add a progress chart for the Packit's 2023/Q4 goal.


Screenshot using stage data:
![image](https://github.com/packit/dashboard/assets/20214043/9ca32966-5cad-494a-844b-a187435c8610)


---

RELEASE NOTES BEGIN
The usage page at https://dashboard.packit.dev/usage newly shows the number of active projects and the progress of Packit's goal to have 200 projects using release syncing by the end of the year 2023.
RELEASE NOTES END
