### PR TITLE
fix: don't import non-existing endpoint

### DIFF
--- a/packit_dashboard/app.py
+++ b/packit_dashboard/app.py
@@ -3,7 +3,6 @@ from os import getenv
 from flask import Flask
 from flask_talisman import Talisman
 
-from packit_dashboard.api.routes import api
 from packit_dashboard.home.routes import home
 
 app = Flask(
@@ -11,7 +10,6 @@ app = Flask(
     static_folder="frontend/dist/assets",
 )
 
-app.register_blueprint(api)
 # Note: Declare any other flask blueprints or routes above this.
 # Routes declared below this will be rendered by React
 app.register_blueprint(home)


### PR DESCRIPTION
Yes… I've really obliterated it in the previous PR.