### PR TITLE
fix(ResultsPageSRPM): fix missing link when SRPM build fails

### DIFF
--- a/frontend/src/app/Results/ResultsPageSRPM.tsx
+++ b/frontend/src/app/Results/ResultsPageSRPM.tsx
@@ -171,7 +171,7 @@ const ResultsPageSRPM = () => {
                       {" "}
                       (
                       <a
-                        href={data.logs_url}
+                        href={data.logs_url ? data.logs_url : `${URL}/builder-live.log`}
                         rel="noreferrer"
                         target={"_blank"}
                       >

--- a/frontend/src/app/Results/ResultsPageSRPM.tsx
+++ b/frontend/src/app/Results/ResultsPageSRPM.tsx
@@ -171,7 +171,11 @@ const ResultsPageSRPM = () => {
                       {" "}
                       (
                       <a
-                        href={data.logs_url ? data.logs_url : `${URL}/builder-live.log`}
+                        href={
+                          data.logs_url
+                            ? data.logs_url
+                            : `${URL}/builder-live.log`
+                        }
                         rel="noreferrer"
                         target={"_blank"}
                       >


### PR DESCRIPTION
When the RPM build fails during the creation of SRPM, the `Logs` link is missing.

e.g. https://dashboard.packit.dev/results/copr-builds/1279980

Note: This is probably not the correct solution.

---

TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

---

RELEASE NOTES BEGIN
￼
RELEASE NOTES END
