### PR TITLE
feat: Add pipeline detail page

### DIFF
--- a/frontend/src/app/Pipelines/PipelineDetail.tsx
+++ b/frontend/src/app/Pipelines/PipelineDetail.tsx
@@ -1,0 +1,220 @@
+// Copyright Contributors to the Packit project.
+// SPDX-License-Identifier: MIT
+
+import React, { useMemo } from "react";
+
+import {
+  Card,
+  CardBody,
+  CardHeader,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  PageSection,
+  PageSectionVariants,
+  Text,
+  TextContent,
+  Title,
+} from "@patternfly/react-core";
+import { TriggerLink, TriggerSuffix } from "../Trigger/TriggerLink";
+import { Preloader } from "../Preloader/Preloader";
+import { SyncReleaseTargetStatusLabel } from "../StatusLabel/SyncReleaseTargetStatusLabel";
+import { StatusLabel } from "../StatusLabel/StatusLabel";
+import { Timestamp } from "../utils/Timestamp";
+import { useQuery } from "@tanstack/react-query";
+import { useParams } from "react-router";
+import { useTitle } from "../utils/useTitle";
+
+interface StatusItem {
+  packit_id: number;
+  status?: string;
+  target: string;
+}
+
+interface StatusItemSRPM {
+  packit_id: number;
+  status: string;
+  target?: string;
+}
+
+interface DescriptionListStatusProps {
+  route: string;
+  name: string | React.ReactNode;
+  entries: (StatusItem | StatusItemSRPM)[];
+  statusClass: typeof StatusLabel;
+}
+
+const DescriptionListStatus: React.FC<DescriptionListStatusProps> = (props) => {
+  const labels = useMemo(() => {
+    const labelled: React.ReactNode[] = [];
+    props.entries.forEach((entry, i) => {
+      labelled.push(
+        <props.statusClass
+          key={i}
+          status={entry.status ?? entry.target!}
+          target={entry.target}
+          link={`/results/${props.route}/${entry.packit_id}`}
+        />,
+      );
+    });
+    return labelled;
+  }, [props]);
+
+  // Filter out empty statuses
+  if (!labels.length) {
+    return <></>;
+  }
+
+  return (
+    <>
+      <DescriptionListGroup>
+        <DescriptionListTerm>{props.name}</DescriptionListTerm>
+        <DescriptionListDescription>{labels}</DescriptionListDescription>
+      </DescriptionListGroup>
+    </>
+  );
+};
+
+interface PipelineItem {
+  packit_id: number;
+  target: string;
+  status: string;
+}
+
+interface PipelineRun {
+  merged_run_id: number;
+  srpm: {
+    packit_id: number;
+    status: string;
+  };
+  copr: PipelineItem[];
+  koji: PipelineItem[];
+  test_run: PipelineItem[];
+  propose_downstream: PipelineItem[];
+  pull_from_upstream: PipelineItem[];
+  time_submitted: number;
+  trigger?: {
+    repo_namespace: string;
+    repo_name: string;
+    git_repo: string;
+    pr_id: number | null;
+    issue_id: number | null;
+    branch_name: string | null;
+    release: string | null;
+  };
+}
+
+export const PipelineDetail = () => {
+  let { id } = useParams();
+  useTitle(`Pipeline Details ${id}`);
+
+  // TODO (spytec): Once routes are implemented we can use this
+  // const location = useLocation();
+  // const matches = useMatches();
+  // const currentMatch = matches.find(
+  //   (match) => match.pathname === location.pathname
+  // );
+
+  const fetchData = () =>
+    fetch(`${import.meta.env.VITE_API_URL}/runs/merged/${id}`).then(
+      (response) => response.json(),
+    );
+
+  const { isInitialLoading, isError, data, isFetching } = useQuery<PipelineRun>(
+    ["pipeline", id],
+    fetchData,
+  );
+
+  // TODO (spytec): Once routes are implemented we can use this
+  // if we're not inside a specific route, default to copr-builds and redirect
+  // const navigate = useNavigate();
+  // useEffect(() => {
+  //   console.log(matches);
+  //   if (matches[matches.length - 1].id === "pipeline-id") {
+  //     navigate("copr-builds");
+  //   }
+  // }, [navigate]);
+
+  // Show preloader if waiting for API data
+  if (isInitialLoading || data === undefined) {
+    return <Preloader />;
+  }
+
+  // TODO: Redirect to /copr-builds, same as jobs.tsx
+  return (
+    <>
+      <PageSection variant={PageSectionVariants.light}>
+        <TextContent>
+          <Text component="h1">Pipeline details</Text>
+          {data.trigger && (
+            <>
+              <Text component="p">
+                <strong>
+                  <TriggerLink trigger={data.trigger}>
+                    <TriggerSuffix trigger={data.trigger} />
+                  </TriggerLink>
+                </strong>{" "}
+                -{" "}
+                <i>
+                  <Timestamp stamp={data.time_submitted} />
+                </i>
+              </Text>
+            </>
+          )}
+        </TextContent>
+      </PageSection>
+      <PageSection>
+        <Card>
+          <CardHeader>
+            <Title headingLevel="h2">Statuses</Title>
+          </CardHeader>
+          <CardBody>
+            <DescriptionList isHorizontal>
+              <DescriptionListStatus
+                name={"SRPM"}
+                route={"srpm-builds"}
+                statusClass={StatusLabel}
+                entries={data.srpm ? [data.srpm] : []}
+              />
+              <DescriptionListStatus
+                name={"Copr"}
+                route={"copr-builds"}
+                statusClass={StatusLabel}
+                entries={data.copr}
+              />
+              <DescriptionListStatus
+                name={"Koji"}
+                route={"koji-builds"}
+                statusClass={StatusLabel}
+                entries={data.koji}
+              />
+              <DescriptionListStatus
+                name={"Testing Farm"}
+                route={"testing-farm"}
+                statusClass={StatusLabel}
+                entries={data.test_run}
+              />
+              <DescriptionListStatus
+                name={"Propose Downstream"}
+                route={"propose-downstream"}
+                statusClass={SyncReleaseTargetStatusLabel}
+                entries={data.propose_downstream}
+              />
+              <DescriptionListStatus
+                name={"Pull From Upstream"}
+                route={"pull-from-upstream"}
+                statusClass={SyncReleaseTargetStatusLabel}
+                entries={data.pull_from_upstream}
+              />
+            </DescriptionList>
+          </CardBody>
+        </Card>
+      </PageSection>
+      {/* TODO: Place contents from nav here once routes are implemented */}
+      {/* <PageSection>
+        <Outlet />
+      </PageSection> */}
+    </>
+  );
+};

--- a/frontend/src/app/Pipelines/PipelinesTable.tsx
+++ b/frontend/src/app/Pipelines/PipelinesTable.tsx
@@ -11,7 +11,7 @@ import {
 } from "@patternfly/react-table/deprecated";
 
 import { Button, LabelGroup } from "@patternfly/react-core";
-import { TriggerLink } from "../Trigger/TriggerLink";
+import { TriggerLink, TriggerSuffix } from "../Trigger/TriggerLink";
 import { ErrorConnection } from "../Errors/ErrorConnection";
 import { Preloader } from "../Preloader/Preloader";
 import { ForgeIcon } from "../Forge/ForgeIcon";
@@ -21,6 +21,7 @@ import { Timestamp } from "../utils/Timestamp";
 import coprLogo from "../../static/copr.ico";
 import kojiLogo from "../../static/koji.ico";
 import { useInfiniteQuery } from "@tanstack/react-query";
+import { Link } from "react-router-dom";
 
 interface StatusItem {
   packit_id: number;
@@ -80,7 +81,7 @@ interface PipelineRun {
   propose_downstream: PipelineItem[];
   pull_from_upstream: PipelineItem[];
   time_submitted: number;
-  trigger: {
+  trigger?: {
     repo_namespace: string;
     repo_name: string;
     git_repo: string;
@@ -143,6 +144,7 @@ const PipelinesTable = () => {
     const rowsList: (IRow | string[])[] = [];
 
     res.forEach((run) => {
+      if (!run.trigger) return;
       let singleRow = {
         cells: [
           {
@@ -151,7 +153,9 @@ const PipelinesTable = () => {
           {
             title: (
               <strong>
-                <TriggerLink builds={run.trigger} />
+                <Link to={`/pipelines/${run.merged_run_id}`}>
+                  <TriggerSuffix trigger={run.trigger} />
+                </Link>
               </strong>
             ),
           },

--- a/frontend/src/app/routes.tsx
+++ b/frontend/src/app/routes.tsx
@@ -26,6 +26,7 @@ import { TestingFarmResultsTable } from "./Jobs/TestingFarmResultsTable";
 import { BodhiUpdatesTable } from "./Jobs/BodhiUpdatesTable";
 import { Usage } from "./Usage/Usage";
 import { ErrorApp } from "./Errors/ErrorApp";
+import { PipelineDetail } from "./Pipelines/PipelineDetail";
 
 // App routes
 // Those with labels indicate they should be in sidebar
@@ -135,6 +136,22 @@ const routes: RouteObject[] = [
           category: "Dashboards",
           label: "Pipelines",
         },
+      },
+      {
+        element: <PipelineDetail />,
+        path: "/pipelines/:id",
+        id: "pipeline-id",
+        // TODO (spytec): Future enhancement would be to take all the different pipeline information and spew out more data in a child component, similar to how we do it in Jobs. That way we can link to specific tables
+        // children: [
+        //   {
+        //     element: <CoprBuildsTable />,
+        //     index: true,
+        //     path: "copr-builds",
+        //     handle: {
+        //       label: "Copr Builds",
+        //     },
+        //   },
+        // ],
       },
       {
         path: "/projects/:forge",


### PR DESCRIPTION
This adds a new pipeline details page that shows all the
statuses for the different jobs run in the pipeline

There can be a lot of future improvements to this, such as
inline fetching of the different resources and generally including
more fields to the merged pipeline results, however for a MVP this
is as good as can be while being as simple as possible
TODO:

- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge after
* #386 

---

RELEASE NOTES BEGIN
Add pipeline details page
RELEASE NOTES END
