### PR TITLE
feat(UX): Step timeline for Copr build status

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "@imranbarbhuiya/duration": "^5.1.8",
     "@patternfly/patternfly": "^5.1.0",
     "@patternfly/react-charts": "^7.1.1",
     "@patternfly/react-core": "^5.1.1",

--- a/frontend/src/app/Results/ResultProgressStep.tsx
+++ b/frontend/src/app/Results/ResultProgressStep.tsx
@@ -1,0 +1,109 @@
+// Copyright Contributors to the Packit project.
+// SPDX-License-Identifier: MIT
+
+import React, { useMemo } from "react";
+import { ProgressStepper, ProgressStep, Tooltip } from "@patternfly/react-core";
+import { Timestamp } from "../utils/Timestamp";
+import { prettyFormat } from "@imranbarbhuiya/duration";
+
+export interface ResultProgressStepProps {
+  submittedTime: number;
+  startTime?: number;
+  finishedTime?: number;
+  noun?: string;
+}
+
+/**
+ * This is for the results pages specifically
+ * At the moment it has a fixed step count of 2, for submitted and
+ * build itself. However, this can be more versatile if need be
+ * as we can change to a higher level component and use React contexts
+ *
+ * TODO (spytec): When/If we have consolidated the list of different
+ * statuses between our results, such as a Results utility to help
+ * us decide if a build/run is successful, in progress, failed, or
+ * has warnings. Then we can incorporate that into this component to indicate where the failure is.
+ *
+ * @author Freya Gustavsson <freya@spytec.se>
+ */
+export const ResultProgressStep: React.FC<ResultProgressStepProps> = ({
+  noun = "Build",
+  submittedTime,
+  startTime,
+  finishedTime,
+}) => {
+  const submittedStep = useMemo(() => {
+    const isCurrent = !startTime;
+    return (
+      <ProgressStep
+        isCurrent={isCurrent}
+        variant={isCurrent ? "info" : "success"}
+        id="step-submitted"
+        description={<Timestamp stamp={submittedTime} />}
+        titleId="step-submitted-title"
+        aria-label="has been submitted"
+      >
+        Submitted
+      </ProgressStep>
+    );
+  }, [startTime]);
+
+  const startStep = useMemo(() => {
+    const isPending = !startTime;
+    const isCurrent = !isPending && !finishedTime;
+
+    // Convert UNIX timestamp into date object, Date gets passed **milliseconds**
+    // since Epoch.
+    const startedTimeEpoch = startTime
+      ? new Date(1000 * startTime).toLocaleString()
+      : "";
+
+    const finishedTimeEpoch = finishedTime
+      ? new Date(1000 * finishedTime).toLocaleString()
+      : "";
+
+    return (
+      <ProgressStep
+        isCurrent={isCurrent}
+        variant={isPending ? "pending" : isCurrent ? "info" : "success"}
+        id="step-submitted"
+        description={
+          startTime && finishedTime ? (
+            <Tooltip
+              content={
+                <span>
+                  Started {startedTimeEpoch}
+                  <br />
+                  Ended {finishedTimeEpoch}
+                </span>
+              }
+            >
+              <span>
+                Took {prettyFormat((finishedTime - startTime) * 6000)}
+              </span>
+            </Tooltip>
+          ) : startTime ? (
+            startTime && (
+              <>
+                Started <Timestamp stamp={startTime} />
+              </>
+            )
+          ) : (
+            ""
+          )
+        }
+        titleId="step-submitted-title"
+        aria-label="has been submitted"
+      >
+        {noun} {isPending ? "Pending" : isCurrent ? "In Progress" : "Done"}
+      </ProgressStep>
+    );
+  }, [startTime]);
+
+  return (
+    <ProgressStepper aria-label={`Current ${noun.toLowerCase()} status`}>
+      {submittedStep}
+      {startStep}
+    </ProgressStepper>
+  );
+};

--- a/frontend/src/app/Results/ResultsPageCoprDetails.tsx
+++ b/frontend/src/app/Results/ResultsPageCoprDetails.tsx
@@ -15,6 +15,7 @@ import React from "react";
 import { StatusLabel } from "../StatusLabel/StatusLabel";
 import { Link, NavLink } from "react-router-dom";
 import { LabelLink } from "../utils/LabelLink";
+import { ResultProgressStep } from "./ResultProgressStep";
 
 export interface ResultsPageCoprDetailsProps {
   data: CoprResult;
@@ -52,17 +53,15 @@ export const ResultsPageCoprDetails: React.FC<ResultsPageCoprDetailsProps> = ({
         </DescriptionListDescription>
       </DescriptionListGroup>
       <DescriptionListGroup>
-        <DescriptionListTerm>Build Submitted Time</DescriptionListTerm>
+        <DescriptionListTerm>
+          <span className="pf-v5-u-screen-reader">Copr build timeline</span>
+        </DescriptionListTerm>
         <DescriptionListDescription>
-          <Timestamp stamp={data.build_submitted_time} verbose={true} />
-        </DescriptionListDescription>
-        <DescriptionListTerm>Build Start Time</DescriptionListTerm>
-        <DescriptionListDescription>
-          <Timestamp stamp={data.build_start_time} verbose={true} />
-        </DescriptionListDescription>
-        <DescriptionListTerm>Build Finish Time</DescriptionListTerm>
-        <DescriptionListDescription>
-          <Timestamp stamp={data.build_finished_time} verbose={true} />
+          <ResultProgressStep
+            submittedTime={data.build_submitted_time}
+            startTime={data.build_start_time}
+            finishedTime={data.build_finished_time}
+          />
         </DescriptionListDescription>
       </DescriptionListGroup>
     </DescriptionList>

--- a/frontend/src/app/utils/Timestamp.tsx
+++ b/frontend/src/app/utils/Timestamp.tsx
@@ -44,7 +44,7 @@ const prettyTimeDifference = (difference: number) => {
   return `${numericPart ? Math.floor(numericPart) : ""}${units}`;
 };
 
-const getPrettyTime = (date: number | Date | null) => {
+export const getPrettyTime = (date: number | Date | null) => {
   if (date === null) {
     return null;
   }
@@ -62,7 +62,7 @@ interface TimestampProps {
   verbose?: boolean;
 }
 
-const Timestamp: React.FC<TimestampProps> = (props) => {
+export const Timestamp: React.FC<TimestampProps> = (props) => {
   if (props.stamp === null) {
     return <span>not provided</span>;
   }
@@ -84,5 +84,3 @@ const Timestamp: React.FC<TimestampProps> = (props) => {
     </Tooltip>
   );
 };
-
-export { Timestamp };

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1329,6 +1329,11 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
+"@imranbarbhuiya/duration@^5.1.8":
+  version "5.1.8"
+  resolved "https://registry.yarnpkg.com/@imranbarbhuiya/duration/-/duration-5.1.8.tgz#b2d096141ac6e0be631b8ea1652623244fbdb222"
+  integrity sha512-6IgX7zR6YW3wpPEhtjQaP3SSLKeYDpTs4QHEEbK3WQDjTloMtyECaFEmv1HETa5Yib/rXkIzOvsu98a0A5otjA==
+
 "@isaacs/cliui@^8.0.2":
   version "8.0.2"
   resolved "https://registry.yarnpkg.com/@isaacs/cliui/-/cliui-8.0.2.tgz#b37667b7bc181c168782259bab42474fbf52b550"


### PR DESCRIPTION
Introduces a step timeline functionality in place of the existing text fields. Visually it will at a glance give a more holistic view at a glance without removing any of the necessary detail one might want.

Throughout the whole stage, the change will indicate when something started and when it ended. Visually in time-relative means with detailed timedate variant on hover using Tooltips

This should be seen as an MVP as it currently lacks relative information such as build status and links to the different steps. In the future, this can be adapted to other results pages.

![visual representation of progress step for Copr builds](https://github.com/packit/dashboard/assets/6598829/666edb5c-e2c0-4fa5-b63d-cccd68c4a3fe)


<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN
UX improvement for Copr build timeline
RELEASE NOTES END
