### PR TITLE
fix: PipelinesTable incorrectly using TriggerLink

### DIFF
--- a/frontend/src/app/Pipelines/PipelinesTable.tsx
+++ b/frontend/src/app/Pipelines/PipelinesTable.tsx
@@ -11,7 +11,7 @@ import {
 } from "@patternfly/react-table/deprecated";
 
 import { Button, LabelGroup } from "@patternfly/react-core";
-import { TriggerLink } from "../Trigger/TriggerLink";
+import { TriggerLink, TriggerSuffix } from "../Trigger/TriggerLink";
 import { ErrorConnection } from "../Errors/ErrorConnection";
 import { Preloader } from "../Preloader/Preloader";
 import { ForgeIcon } from "../Forge/ForgeIcon";
@@ -151,7 +151,9 @@ const PipelinesTable = () => {
           {
             title: (
               <strong>
-                <TriggerLink builds={run.trigger} />
+                <TriggerLink trigger={run.trigger}>
+                  <TriggerSuffix trigger={run.trigger} />
+                </TriggerLink>
               </strong>
             ),
           },


### PR DESCRIPTION
We migrated TriggerLink to use the term trigger instead of build to be
more accurate. With that change we also split the text and link to be
separate, which we didn't address in the PipelinesTable either

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN
Fix pipelines showing e is undefined
RELEASE NOTES END
