### PR TITLE
Expose SENTRY_AUTH_TOKEN for frontend build

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -42,6 +42,11 @@ jobs:
           echo "commit_sha=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
         id: branch_tag
 
+      - name: Set up secret file needed for the build
+        run: echo "$SENTRY_AUTH_TOKEN" > /tmp/sentry-secret
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+
       - name: Build Image
         id: build-image
         # https://github.com/marketplace/actions/buildah-build
@@ -53,6 +58,8 @@ jobs:
           build-args: |
             VITE_API_URL=${{ steps.branch_tag.outputs.api }}
             VITE_GIT_SHA=${{ steps.branch_tag.outputs.commit_sha }}
+          extra-args: |
+            --secret id=sentry_auth_token,src=/tmp/sentry-secret
           oci: true
 
       - name: Push To Quay

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,8 @@ COPY packit_dashboard/  packit_dashboard/
 COPY frontend/ frontend/
 
 COPY files/ files/
-RUN ansible-playbook -vv -c local -i localhost, files/ansible/recipe.yaml
+RUN --mount=type=secret,id=sentry_auth_token export SENTRY_AUTH_TOKEN=$(cat /run/secrets/sentry_auth_token); \
+ansible-playbook -vv -c local -i localhost, files/ansible/recipe.yaml
 
 EXPOSE 8443
 


### PR DESCRIPTION
Followup of #410

I would like to avoid writing the secret into a file, but the `buildah` version in the action doesn't support env vars. Therefore open to any suggestions and opening it as draft :pray: