### PR TITLE
fix: move Sentry dependency from dev to prod

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -12,6 +12,7 @@
     "@patternfly/react-styles": "5.1.1",
     "@patternfly/react-table": "5.1.1",
     "@sentry/react": "^8.2.1",
+    "@sentry/vite-plugin": "^2.16.1",
     "@tanstack/react-query": "^4.29.7",
     "@testing-library/dom": "^9.3.1",
     "@testing-library/jest-dom": "^5.16.5",
@@ -120,7 +121,6 @@
     ]
   },
   "devDependencies": {
-    "@sentry/vite-plugin": "^2.16.1",
     "@storybook/addon-a11y": "^7.0.9",
     "@storybook/addon-actions": "^7.0.9",
     "@storybook/addon-essentials": "^7.0.9",


### PR DESCRIPTION
When we do production builds we use --production, which skips the
devDependencies completely. Moving `@sentry/vite-plugin` to dependencies
will fix this issue

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

N/A

RELEASE NOTES END
