### PR TITLE
chore: remove Prettier from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,6 @@ repos:
     hooks:
       - id: black
         language_version: python3
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        exclude: frontend/tsconfig.json
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:


### PR DESCRIPTION
Pre-commit prettier is not maintained anymore and if we want to run it
we should consider an alternative way

https://github.com/pre-commit/mirrors-prettier


<!-- release notes footer -->

RELEASE NOTES BEGIN
Remove Prettier from pre-commit
RELEASE NOTES END
