### PR TITLE
chore: upgrade ESLint to use new flat config

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,0 +1,51 @@
+// Copyright Contributors to the Packit project.
+// SPDX-License-Identifier: MIT
+
+import eslint from "@eslint/js";
+import * as react from "eslint-plugin-react";
+import tseslint from "typescript-eslint";
+
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    settings: {
+      react: {
+        version: "detect",
+      },
+    },
+    plugins: {
+      react,
+      "@typescript-eslint": tseslint.plugin,
+    },
+    languageOptions: {
+      parser: tseslint.parser,
+      parserOptions: {
+        project: "./tsconfig.json",
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+    },
+    rules: {
+      "import/no-anonymous-default-export": "off",
+      "react/no-unescaped-entities": "off",
+      "react/prop-types": "off",
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          args: "all",
+          argsIgnorePattern: "^_",
+          caughtErrors: "all",
+          caughtErrorsIgnorePattern: "^_",
+          destructuredArrayIgnorePattern: "^_",
+          varsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+        },
+      ],
+    },
+  },
+  {
+    files: ["**/*.{js,jsx,mjs,cjs,ts,tsx}", "**/*.stories.*"],
+  },
+);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,7 +23,6 @@
     "@types/react": "^18.0.29",
     "@types/react-dom": "^18.0.11",
     "@vitejs/plugin-react": "^4.0.1",
-    "eslint": "^8.43.0",
     "msw": "^1.2.1",
     "prettier": "^2.8.3",
     "react": "^18.2.0",
@@ -49,54 +48,6 @@
     "prettier": "prettier --write .",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build"
-  },
-  "eslintConfig": {
-    "ignorePatterns": [
-      "dist/*",
-      "public/*",
-      "frontend/*"
-    ],
-    "settings": {
-      "react": {
-        "version": "detect"
-      }
-    },
-    "parser": "@typescript-eslint/parser",
-    "parserOptions": {
-      "project": "./tsconfig.json"
-    },
-    "extends": [
-      "eslint:recommended",
-      "plugin:@typescript-eslint/recommended-type-checked",
-      "plugin:react/recommended",
-      "plugin:react/jsx-runtime",
-      "plugin:storybook/recommended",
-      "prettier"
-    ],
-    "rules": {
-      "import/no-anonymous-default-export": "off",
-      "react/no-unescaped-entities": "off",
-      "react/prop-types": "off",
-      "@typescript-eslint/no-unused-vars": [
-        "error",
-        {
-          "args": "all",
-          "argsIgnorePattern": "^_",
-          "caughtErrors": "all",
-          "caughtErrorsIgnorePattern": "^_",
-          "destructuredArrayIgnorePattern": "^_",
-          "varsIgnorePattern": "^_",
-          "ignoreRestSiblings": true
-        }
-      ]
-    },
-    "overrides": [
-      {
-        "files": [
-          "**/*.stories.*"
-        ]
-      }
-    ]
   },
   "prettier": {
     "overrides": [
@@ -142,6 +93,7 @@
     "@storybook/theming": "^7.4.0",
     "@storybook/types": "^7.4.0",
     "babel-plugin-named-exports-order": "^0.0.2",
+    "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-storybook": "^0.6.12",

--- a/frontend/src/app/AppLayout/AppLayout.tsx
+++ b/frontend/src/app/AppLayout/AppLayout.tsx
@@ -71,7 +71,6 @@ const AppLayout = () => {
   };
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const onPageResize = (props: any) => {
-    // eslint-disable-next-line react/prop-types
     if (Object.hasOwn(props, "mobileView")) setIsMobileView(props.mobileView);
   };
 

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -5560,7 +5560,7 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz#0cd72fe8550e3c2eae156a96a4dddcd1c8ac5800"
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
-eslint@^8.43.0:
+eslint@^8.57.0:
   version "8.57.0"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.0.tgz#c786a6fd0e0b68941aaf624596fb987089195668"
   integrity sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==


### PR DESCRIPTION
With ESLint 9 being out and plugins slowly migrating, this takes care of
the migration of ESLint config from package.json to its own
eslint.config.mjs. This is needed as package.json and .eslintrc is
deprecated

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN
Upgrade ESLint config structure
RELEASE NOTES END
