### PR TITLE
chore: increase RSA size in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,7 +28,7 @@ make build-stg
 2. Generate private key
 
 ```
-openssl genrsa -des3 -out secrets/privkey.pem 1024
+openssl genrsa -des3 -out secrets/privkey.pem 2048
 ```
 
 3. Generate Certificate Signing Request


### PR DESCRIPTION
We were recommending using 1024 that doesn't work anymore as it is not allowed with mod_wsgi

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN
Increase local certificate generation from 1024 to 2048 for development
RELEASE NOTES END
