### PR TITLE
chore: Enable HTTP/2 protocol for dashboard

### DIFF
--- a/files/ansible/install-deps.yaml
+++ b/files/ansible/install-deps.yaml
@@ -16,6 +16,7 @@
           - "@nodejs:20"
           - python3-mod_wsgi
           - mod_ssl
+          - mod_http2
         state: present
 
     - name: Install pip deps

--- a/files/scripts/run_httpd.sh
+++ b/files/scripts/run_httpd.sh
@@ -13,11 +13,10 @@ fi
 # See "mod_wsgi-express-3 start-server --help" for details on
 # these options, and the configuration documentation of mod_wsgi:
 # https://modwsgi.readthedocs.io/en/master/configuration.html
-# For the HSTS policy see
-# https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
 exec mod_wsgi-express-3 start-server \
     --access-log \
     --log-to-terminal \
+    --http2 \
     --https-port 8443 \
     --ssl-certificate-file /secrets/fullchain.pem \
     --ssl-certificate-key-file /secrets/privkey.pem \

--- a/packit_dashboard/app.py
+++ b/packit_dashboard/app.py
@@ -18,6 +18,10 @@ app = Flask(
 app.register_blueprint(home)
 
 
+# Enable CSP and HSTS
+#
+# For the HSTS policy see
+# https://cheatsheetseries.owasp.org/cheatsheets/HTTP_Strict_Transport_Security_Cheat_Sheet.html
 csp = {
     "default-src": ["'self'", "*.packit.dev"],
     "object-src": "'none'",


### PR DESCRIPTION
With this change we now have mod_http2 installed and enabled. Local testing indicates that HTTP/2 works as intended as seen below

```
❯ curl https://dashboard.localhost:8443/ --insecure --head
HTTP/2 200
content-length: 1564
x-frame-options: SAMEORIGIN
x-xss-protection: 1; mode=block
x-content-type-options: nosniff
content-security-policy: default-src 'self' *.packit.dev; object-src 'none'; style-src 'unsafe-inline' 'self'
strict-transport-security: max-age=31536000;includeSubDomains
referrer-policy: strict-origin-when-cross-origin
content-type: text/html; charset=utf-8
date: Mon, 24 Jun 2024 15:41:03 GMT
server: Apache
```

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN
Enable HTTP/2 for Packit dashboard
RELEASE NOTES END
