### PR TITLE
Fix Copr build installation instructions

### DIFF
--- a/frontend/src/app/Results/ResultsPageCopr.tsx
+++ b/frontend/src/app/Results/ResultsPageCopr.tsx
@@ -149,11 +149,7 @@ const ResultsPageCopr = () => {
             <br />
             <List>
               <ListItem>
-                <code>sudo yum install -y dnf-plugins-core</code> on RHEL 8 or
-                CentOS Stream
-              </ListItem>
-              <ListItem>
-                <code>sudo dnf install -y dnf-plugins-core</code> on Fedora
+                <code>sudo dnf install -y dnf-plugins-core</code>
               </ListItem>
               <ListItem>
                 <code>


### PR DESCRIPTION
`dnf` is in EL since EL8, `yum` there is just a compatibility wrapper. Also the subsequent steps don't consider `yum` at all.
Just get rid of it.