### PR TITLE
Show multiple NVRs on Bodhi update result page

### DIFF
--- a/frontend/src/app/Results/ResultsPageBodhiUpdate.tsx
+++ b/frontend/src/app/Results/ResultsPageBodhiUpdate.tsx
@@ -29,6 +29,7 @@ interface BodhiUpdate {
   status: string;
   alias: string | null;
   web_url: string | null;
+  koji_nvrs: string;
   branch: string;
   submitted_time: number;
   update_creation_time: number | null;
@@ -121,10 +122,10 @@ const ResultsPageBodhiUpdate = () => {
                   {" "}
                   {data.alias !== null ? data.alias : <span>not provided</span>}
                 </DescriptionListDescription>
-                <DescriptionListTerm>Koji NVR</DescriptionListTerm>
+                <DescriptionListTerm>Koji NVRs</DescriptionListTerm>
                 <DescriptionListDescription>
                   {" "}
-                  {data.koji_nvr}
+                  {data.koji_nvrs}
                 </DescriptionListDescription>
               </DescriptionListGroup>
               <DescriptionListGroup>


### PR DESCRIPTION
This will show a space separated list, but perhaps having a NVR per line would be better? If so, I welcome any tips how to do that with PatternFly :slightly_smiling_face: 

Related to https://github.com/packit/packit-service/issues/2379.

Merge after https://github.com/packit/packit-service/pull/2475.