### PR TITLE
fix: Always show build log link for SRPM

### DIFF
--- a/frontend/src/components/srpm/SRPMBuild.tsx
+++ b/frontend/src/components/srpm/SRPMBuild.tsx
@@ -116,23 +116,17 @@ export const SRPMBuild = () => {
                 <DescriptionListTerm>Copr build</DescriptionListTerm>
                 <DescriptionListDescription>
                   <StatusLabel status={data.status} link={data.copr_web_url} />{" "}
+                  {data.logs_url ? (
+                    <a href={data.logs_url} rel="noreferrer" target={"_blank"}>
+                      Build logs
+                    </a>
+                  ) : (
+                    <></>
+                  )}
                   {data.url ? (
-                    <>
-                      {" "}
-                      (
-                      <a
-                        href={data.logs_url}
-                        rel="noreferrer"
-                        target={"_blank"}
-                      >
-                        Logs
-                      </a>
-                      ) (
-                      <a href={data.url} rel="noreferrer" target={"_blank"}>
-                        Results
-                      </a>
-                      )
-                    </>
+                    <a href={data.url} rel="noreferrer" target={"_blank"}>
+                      Results
+                    </a>
                   ) : (
                     <></>
                   )}


### PR DESCRIPTION
This makes the build log always visible as it will always return from
packit. Otherwise users would not get any logs when an SRPM build has
failed, meaning they would have to chase it down through the link

Takes up on results from #371

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN
Always show SRPM Build logs
RELEASE NOTES END
