### PR TITLE
fix: add parenthesis back to SRPM Build log links

### DIFF
--- a/frontend/src/components/srpm/SRPMBuild.tsx
+++ b/frontend/src/components/srpm/SRPMBuild.tsx
@@ -117,16 +117,28 @@ export const SRPMBuild = () => {
                 <DescriptionListDescription>
                   <StatusLabel status={data.status} link={data.copr_web_url} />{" "}
                   {data.logs_url ? (
-                    <a href={data.logs_url} rel="noreferrer" target={"_blank"}>
-                      Build logs
-                    </a>
+                    <>
+                      (
+                      <a
+                        href={data.logs_url}
+                        rel="noreferrer"
+                        target={"_blank"}
+                      >
+                        Build logs
+                      </a>
+                      )
+                    </>
                   ) : (
                     <></>
-                  )}
+                  )}{" "}
                   {data.url ? (
-                    <a href={data.url} rel="noreferrer" target={"_blank"}>
-                      Results
-                    </a>
+                    <>
+                      (
+                      <a href={data.url} rel="noreferrer" target={"_blank"}>
+                        Results
+                      </a>
+                      )
+                    </>
                   ) : (
                     <></>
                   )}


### PR DESCRIPTION
In a previous PR I removed the parenthesis as part of the refactor
without noticing. This commit adds it back

![image](https://github.com/user-attachments/assets/c4a5cd9d-db6c-4e9c-b9dc-0dfab7545fa1)


<!-- release notes footer -->

RELEASE NOTES BEGIN
Fix Build logs and Results for SRPM builds not being in parenthesis
RELEASE NOTES END
