### PR TITLE
fix: builds failing due to pnpm

### DIFF
--- a/files/ansible/recipe.yaml
+++ b/files/ansible/recipe.yaml
@@ -14,7 +14,6 @@
 
     - name: install node modules
       command:
-        chdir: "{{ packit_dashboard_path }}"
         cmd: pnpm install --prod --frozen-lockfile
 
     - name: bundle javascript


### PR DESCRIPTION
With the new restructure to use workspaces with pnpm we need to run the install within the workspace itself rather than in /frontend. We need the workspace as biome CI will work better when we have the pnpm packages in the project root


RELEASE NOTES BEGIN
Fix builds failing due to incorrect folder
RELEASE NOTES END
