### PR TITLE
fix: preview PR with set NodeJS version

### DIFF
--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -42,7 +42,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: "lts"
+          node-version: "20"
           cache: "pnpm"
           cache-dependency-path: frontend/pnpm-lock.yaml
 


### PR DESCRIPTION
This sets the nodejs version from lts to 20 as
lts itself needs to be more specific

RELEASE NOTES BEGIN
Fix PR preview for dashboard
RELEASE NOTES END
