### PR TITLE
Add missing states to status labels

### DIFF
--- a/frontend/src/components/statusLabels/StatusLabel.tsx
+++ b/frontend/src/components/statusLabels/StatusLabel.tsx
@@ -2,9 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import {
+  AngleDoubleRightIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,
+  HourglassHalfIcon,
+  InProgressIcon,
   InfoCircleIcon,
 } from "@patternfly/react-icons";
 import React, { useEffect, useState } from "react";
@@ -38,6 +41,18 @@ export const StatusLabel: React.FC<StatusLabelProps> = (props) => {
       case "error":
         setColor("orange");
         setIcon(<ExclamationTriangleIcon />);
+        break;
+      case "pending":
+        setColor("cyan");
+        setIcon(<HourglassHalfIcon />);
+        break;
+      case "running":
+        setColor("blue");
+        setIcon(<InProgressIcon />);
+        break;
+      case "skipped":
+        setColor("grey");
+        setIcon(<AngleDoubleRightIcon />);
         break;
     }
   }, [props.status]);


### PR DESCRIPTION
New colors and icons for:
* running
* pending
* skipped

Fixes #460

<!-- TODO list -->

TODO:

- [ ] Write new tests or update the old ones to cover new functionality.
- [ ] Update doc-strings where appropriate.
- [ ] Update or write new documentation in `packit/packit.dev`.
- [ ] ‹fill in›

<!-- notes for reviewers -->

<!-- Links to other issues or pull requests,
     for cross-repository links use: ‹namespace›/‹repository›#‹ID of issue›
       (‹namespace›/‹repository›!‹ID of PR› respectively)
-->

Fixes

Related to

Merge before/after

<!-- release notes footer -->

RELEASE NOTES BEGIN

Previously the pending status had same color and icon as skipped status.

Now we added the icons and colors for those two statuses, that are different from each other, and this had changed also for the running state.

RELEASE NOTES END
