### PR TITLE
feat: More build info in Testing Farm runs

### DIFF
--- a/frontend/src/components/statusLabels/StatusLabel.tsx
+++ b/frontend/src/components/statusLabels/StatusLabel.tsx
@@ -9,6 +9,7 @@ import {
   HourglassHalfIcon,
   InProgressIcon,
   InfoCircleIcon,
+  QuestionCircleIcon,
 } from "@patternfly/react-icons";
 import React, { useEffect, useState } from "react";
 import { BaseStatusLabel, BaseStatusLabelProps } from "./BaseStatusLabel";
@@ -53,6 +54,10 @@ export const StatusLabel: React.FC<StatusLabelProps> = (props) => {
       case "skipped":
         setColor("grey");
         setIcon(<AngleDoubleRightIcon />);
+        break;
+      case "unknown":
+        setColor("grey");
+        setIcon(<QuestionCircleIcon />);
         break;
     }
   }, [props.status]);

--- a/frontend/src/components/testing-farm/CoprDataListItem.tsx
+++ b/frontend/src/components/testing-farm/CoprDataListItem.tsx
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import {
+  Button,
   DataListCell,
   DataListContent,
   DataListItem,
@@ -10,20 +11,21 @@ import {
   DataListToggle,
   Skeleton,
 } from "@patternfly/react-core";
+import { ExternalLinkSquareAltIcon } from "@patternfly/react-icons";
 import { queryOptions, useQuery } from "@tanstack/react-query";
 import { Link } from "@tanstack/react-router";
 import { useState } from "react";
 import React from "react";
 import { coprBuildQueryOptions } from "../../queries/copr/coprBuildQuery";
 import { CoprBuildDetail } from "../copr/CoprBuildDetail";
+import { StatusLabel } from "../statusLabels/StatusLabel";
 
 interface CoprDataListItemProps {
   id: number;
 }
 
 export const CoprDataListItem: React.FC<CoprDataListItemProps> = ({ id }) => {
-  const [isExpanded, setIsExpanded] = useState(false);
-  const { data, isError } = useQuery(
+  const { data, isError, isLoading } = useQuery(
     queryOptions({
       ...coprBuildQueryOptions({ id: id.toString() }),
     }),
@@ -34,30 +36,32 @@ export const CoprDataListItem: React.FC<CoprDataListItemProps> = ({ id }) => {
   }
 
   return (
-    <DataListItem key={`copr-${id}-item`} isExpanded={isExpanded}>
+    <DataListItem key={`copr-${id}-item`}>
       <DataListItemRow key={`copr-${id}-row`}>
-        <DataListToggle
-          isExpanded={isExpanded}
-          id={`copr-build-toggle${id}`}
-          aria-controls={`copr-build-expand${id}`}
-          onClick={() => setIsExpanded(!isExpanded)}
-        />
         <DataListItemCells
           dataListCells={[
             <DataListCell key={1}>
-              <Link to={`/jobs/copr/${id}`}>{id}</Link>
+              <StatusLabel
+                target={data?.chroot}
+                status={data ? data.status : "unknown"}
+                link={`/jobs/copr/${id}`}
+              />
+              <Button
+                component="a"
+                variant="link"
+                isLoading={isLoading}
+                href={data?.build_logs_url}
+                rel="noreferrer"
+                target={"_blank"}
+                icon={<ExternalLinkSquareAltIcon />}
+                iconPosition="end"
+              >
+                Logs
+              </Button>
             </DataListCell>,
           ]}
         ></DataListItemCells>
       </DataListItemRow>
-      <DataListContent
-        key={id + "content"}
-        aria-label="Copr build detail"
-        isHidden={!isExpanded}
-        id={`copr-build-expand-${id}`}
-      >
-        {data ? <CoprBuildDetail data={data} /> : <Skeleton height="5rem" />}
-      </DataListContent>
     </DataListItem>
   );
 };


### PR DESCRIPTION
This adds more information while also taking away some extra steps
relating to the Copr builds associated with the testing farm results.

Now looks like this
![image](https://github.com/user-attachments/assets/859deb68-7964-4d78-983e-10c953aeb4a1)

RELEASE NOTES BEGIN
Improve UX of Copr builds in Testing Farm runs
RELEASE NOTES END
