### PR TITLE
Introduce views for OpenScanHub

### DIFF
--- a/frontend/src/apiDefinitions.ts
+++ b/frontend/src/apiDefinitions.ts
@@ -389,3 +389,50 @@ export interface PipelineRun {
     | null;
   vm_image_build: unknown[]; //TODO - @Venefilyn - No clue what it should be
 }
+
+// /api/osh-scans
+export interface OSHScanGroup {
+  packit_id: number;
+  anitya_package: string | null;
+  anitya_project_id: number | null;
+  anitya_project_name: string | null;
+  anitya_version: string | null;
+  branch_name: string | null;
+  commit_sha: string;
+  non_git_upstream: boolean;
+  pr_id: number | null;
+  project_url: string;
+  release: string | null;
+  repo_name: string;
+  repo_namespace: string;
+  copr_build_target_id: number;
+  status: string;
+  task_id: number;
+  url: string;
+  issues_added_url: string;
+  issues_fixed_url: string;
+  scan_results_url: string;
+}
+
+// /api/osh-scans/$id
+export interface OSHScan {
+  anitya_package: string | null;
+  anitya_project_id: number | null;
+  anitya_project_name: string | null;
+  anitya_version: string | null;
+  branch_name: string | null;
+  commit_sha: string;
+  non_git_upstream: boolean;
+  pr_id: number | null;
+  project_url: string;
+  release: string | null;
+  repo_name: string;
+  repo_namespace: string;
+  copr_build_target_id: number;
+  status: string;
+  task_id: number;
+  url: string;
+  issues_added_url: string;
+  issues_fixed_url: string;
+  scan_results_url: string;
+}

--- a/frontend/src/components/jobs/Jobs.tsx
+++ b/frontend/src/components/jobs/Jobs.tsx
@@ -61,6 +61,9 @@ const Jobs = () => {
           <NavItem isActive={!!matchRoute(jobTypeObject("bodhi"))}>
             <Link {...jobTypeObject("bodhi")}>Bodhi Updates</Link>
           </NavItem>
+          <NavItem isActive={!!matchRoute(jobTypeObject("osh-scans"))}>
+            <Link {...jobTypeObject("osh-scans")}>OpenScanHub Scans</Link>
+          </NavItem>
         </NavList>
       </Nav>
       <PageSection hasBodyWrapper={false}>

--- a/frontend/src/components/osh/OSHScan.tsx
+++ b/frontend/src/components/osh/OSHScan.tsx
@@ -1,0 +1,147 @@
+// Copyright Contributors to the Packit project.
+// SPDX-License-Identifier: MIT
+
+import {
+  Card,
+  CardBody,
+  Content,
+  DescriptionList,
+  DescriptionListDescription,
+  DescriptionListGroup,
+  DescriptionListTerm,
+  PageSection,
+  Title,
+} from "@patternfly/react-core";
+import { useQuery } from "@tanstack/react-query";
+import { oshScanQueryOptions } from "../../queries/osh/oshScanQuery";
+import { Route as OSHScanRoute } from "../../routes/jobs_/osh-scans.$id";
+import { ErrorConnection } from "../errors/ErrorConnection";
+import { LabelLink } from "../shared/LabelLink";
+import { Preloader } from "../shared/Preloader";
+import { Timestamp } from "../shared/Timestamp";
+import { StatusLabel } from "../statusLabels/StatusLabel";
+import { TriggerLink, TriggerSuffix } from "../trigger/TriggerLink";
+
+export const OSHScan = () => {
+  const { id } = OSHScanRoute.useParams();
+
+  const { data, isError, isLoading } = useQuery(oshScanQueryOptions({ id }));
+
+  // If backend API is down
+  if (isError) {
+    return <ErrorConnection />;
+  }
+
+  // Show preloader if waiting for API data
+  if (isLoading || data === undefined) {
+    return <Preloader />;
+  }
+
+  if ("error" in data) {
+    return (
+      <PageSection hasBodyWrapper={false}>
+        <Card>
+          <CardBody>
+            <Title headingLevel="h1" size="lg">
+              Not Found.
+            </Title>
+          </CardBody>
+        </Card>
+      </PageSection>
+    );
+  }
+
+  return (
+    <>
+      <PageSection hasBodyWrapper={false}>
+        <Content>
+          <Content component="h1">OpenScanHub Scan Results</Content>
+          <Content component="p">
+            <strong>
+              <TriggerLink trigger={data}>
+                <TriggerSuffix trigger={data} />
+              </TriggerLink>
+              {/* <SHACopy project_url={data.project_url} commit_sha={data.commit_sha} /> */}
+            </strong>
+            <br />
+          </Content>
+        </Content>
+      </PageSection>
+
+      <PageSection hasBodyWrapper={false}>
+        <Card>
+          <CardBody>
+            <DescriptionList
+              columnModifier={{
+                default: "1Col",
+                sm: "2Col",
+              }}
+            >
+              <DescriptionListGroup>
+                <DescriptionListTerm>Status</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <StatusLabel
+                    status={data.status}
+                    target={"rawhide"}
+                    link={data.url}
+                  />
+                </DescriptionListDescription>
+
+                {data.status === "succeeded" ? (
+                  <>
+                    <DescriptionListTerm>Result files</DescriptionListTerm>
+                    <DescriptionListDescription>
+                      <div>
+                        <a
+                          href={data.issues_added_url}
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          Added issues
+                        </a>
+                      </div>
+                      <div>
+                        <a
+                          href={data.issues_fixed_url}
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          Fixed issues
+                        </a>
+                      </div>
+                      <div>
+                        <a
+                          href={data.scan_results_url}
+                          rel="noreferrer"
+                          target="_blank"
+                        >
+                          All results
+                        </a>
+                      </div>
+                    </DescriptionListDescription>
+                  </>
+                ) : (
+                  <></>
+                )}
+              </DescriptionListGroup>
+              <DescriptionListGroup>
+                <DescriptionListTerm>Scan Submitted Time</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <Timestamp stamp={data.submitted_time} verbose={true} />
+                </DescriptionListDescription>
+                <DescriptionListTerm>Copr Build</DescriptionListTerm>
+                <DescriptionListDescription>
+                  <LabelLink
+                    to={`/jobs/copr-builds/${data.copr_build_target_id}`}
+                  >
+                    Details
+                  </LabelLink>
+                </DescriptionListDescription>
+              </DescriptionListGroup>
+            </DescriptionList>
+          </CardBody>
+        </Card>
+      </PageSection>
+    </>
+  );
+};

--- a/frontend/src/components/osh/OSHScansTable.tsx
+++ b/frontend/src/components/osh/OSHScansTable.tsx
@@ -1,0 +1,133 @@
+// Copyright Contributors to the Packit project.
+// SPDX-License-Identifier: MIT
+
+import { useMemo } from "react";
+
+import {
+  Table,
+  TableVariant,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from "@patternfly/react-table";
+
+import { SkeletonTable } from "@patternfly/react-component-groups";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { ErrorConnection } from "../../components/errors/ErrorConnection";
+import { Timestamp } from "../../components/shared/Timestamp";
+import {
+  TriggerLink,
+  TriggerSuffix,
+} from "../../components/trigger/TriggerLink";
+import { oshScansQueryOptions } from "../../queries/osh/oshScansQuery";
+import { ForgeIcon, ForgeIconByForge } from "../icons/ForgeIcon";
+import { LoadMore } from "../shared/LoadMore";
+import { StatusLabel } from "../statusLabels/StatusLabel";
+
+const OSHScansTable = () => {
+  // Headings
+  const columnNames = {
+    forge: "Forge",
+    trigger: "Trigger",
+    scan: "OpenScanHub task",
+    branch: "Scan details",
+    timeProcessed: "Time Processed",
+  };
+
+  const {
+    isLoading,
+    isError,
+    fetchNextPage,
+    data,
+    isFetchingNextPage,
+    hasNextPage,
+  } = useInfiniteQuery(oshScansQueryOptions());
+
+  // Create a memoization of all the data when we flatten it out. Ideally one should render all the pages separately so that rendering will be done faster
+  const rows = useMemo(() => (data ? data.pages.flat() : []), [data]);
+
+  const TableHeads = [
+    <Th key={columnNames.forge}>
+      <span className="pf-v6-u-screen-reader">{columnNames.forge}</span>
+    </Th>,
+    <Th key={columnNames.trigger} width={35}>
+      {columnNames.trigger}
+    </Th>,
+    <Th key={columnNames.branch} width={20}>
+      {columnNames.branch}
+    </Th>,
+    <Th key={columnNames.timeProcessed} width={20}>
+      {columnNames.timeProcessed}
+    </Th>,
+    <Th key={columnNames.scan} width={20}>
+      {columnNames.scan}
+    </Th>,
+  ];
+
+  // If backend API is down
+  if (isError) {
+    return <ErrorConnection />;
+  }
+
+  if (isLoading) {
+    return (
+      <SkeletonTable
+        variant={TableVariant.compact}
+        rows={10}
+        columns={TableHeads}
+      />
+    );
+  }
+
+  return (
+    <>
+      <Table aria-label="OpenScanHub scans" variant={TableVariant.compact}>
+        <Thead>
+          <Tr>{TableHeads}</Tr>
+        </Thead>
+        <Tbody>
+          {rows.map((scan) => (
+            <Tr key={scan.packit_id}>
+              <Td dataLabel={columnNames.forge}>
+                <ForgeIcon url={scan.project_url} />
+              </Td>
+              <Td dataLabel={columnNames.trigger}>
+                <strong>
+                  <TriggerLink trigger={scan}>
+                    <TriggerSuffix trigger={scan} />
+                  </TriggerLink>
+                </strong>
+              </Td>
+              <Td dataLabel={columnNames.branch}>
+                <StatusLabel
+                  target={"rawhide"}
+                  status={scan.status}
+                  link={`/jobs/osh-scans/${scan.packit_id}`}
+                />
+              </Td>
+              <Td dataLabel={columnNames.timeProcessed}>
+                <Timestamp stamp={scan.submitted_time} />
+              </Td>
+              <Td dataLabel={columnNames.bodhiUpdate}>
+                <strong>
+                  <a href={scan.url ?? ""} target="_blank" rel="noreferrer">
+                    {scan.task_id}
+                  </a>
+                </strong>
+              </Td>
+            </Tr>
+          ))}
+        </Tbody>
+      </Table>
+      <LoadMore
+        isFetchingNextPage={isFetchingNextPage}
+        hasNextPage={hasNextPage}
+        fetchNextPage={() => void fetchNextPage()}
+      />
+    </>
+  );
+};
+
+export { OSHScansTable };

--- a/frontend/src/components/statusLabels/StatusLabel.tsx
+++ b/frontend/src/components/statusLabels/StatusLabel.tsx
@@ -28,6 +28,7 @@ export const StatusLabel: React.FC<StatusLabelProps> = (props) => {
 
   useEffect(() => {
     switch (props.status) {
+      case "succeeded":
       case "success":
       case "passed":
         setColor("green");

--- a/frontend/src/queries/osh/oshScan.ts
+++ b/frontend/src/queries/osh/oshScan.ts
@@ -1,0 +1,27 @@
+// Copyright Contributors to the Packit project.
+// SPDX-License-Identifier: MIT
+
+import { OSHScan } from "../../apiDefinitions";
+
+export interface fetchOSHScanProps {
+  id: string;
+  signal?: AbortSignal;
+}
+
+// Fetch data from dashboard backend (or if we want, directly from the API)
+export const fetchOSHScan = async ({
+  id,
+  signal,
+}: fetchOSHScanProps): Promise<OSHScan> => {
+  const data = await fetch(`${import.meta.env.VITE_API_URL}/osh-scans/${id}`, {
+    signal,
+  })
+    .then((response) => response.json())
+    .catch((err) => {
+      if (err.status === 404) {
+        throw new Error(`OSH scan ${id} not found!`);
+      }
+      throw err;
+    });
+  return data;
+};

--- a/frontend/src/queries/osh/oshScanQuery.ts
+++ b/frontend/src/queries/osh/oshScanQuery.ts
@@ -1,0 +1,13 @@
+// Copyright Contributors to the Packit project.
+// SPDX-License-Identifier: MIT
+
+import { queryOptions } from "@tanstack/react-query";
+import { fetchOSHScan, fetchOSHScanProps } from "./oshScan";
+
+type QueryParameters = Omit<fetchOSHScanProps, "signal">;
+
+export const oshScanQueryOptions = (params: QueryParameters) =>
+  queryOptions({
+    queryKey: ["bodhi", params],
+    queryFn: async ({ signal }) => await fetchOSHScan({ signal, ...params }),
+  });

--- a/frontend/src/queries/osh/oshScans.ts
+++ b/frontend/src/queries/osh/oshScans.ts
@@ -1,0 +1,28 @@
+// Copyright Contributors to the Packit project.
+// SPDX-License-Identifier: MIT
+
+import { OSHScanGroup } from "../../apiDefinitions";
+
+export interface fetchScansProps {
+  pageParam: number;
+  signal?: AbortSignal;
+}
+
+// Fetch data from dashboard backend (or if we want, directly from the API)
+export const fetchScans = async ({
+  pageParam = 1,
+  signal,
+}: fetchScansProps): Promise<OSHScanGroup[]> => {
+  const data = await fetch(
+    `${import.meta.env.VITE_API_URL}/osh-scans?page=${pageParam}`,
+    { signal },
+  )
+    .then((response) => response.json())
+    .catch((err) => {
+      if (err.status === 404) {
+        throw new Error(`OSH scans not found!`);
+      }
+      throw err;
+    });
+  return data;
+};

--- a/frontend/src/queries/osh/oshScansQuery.ts
+++ b/frontend/src/queries/osh/oshScansQuery.ts
@@ -1,0 +1,25 @@
+// Copyright Contributors to the Packit project.
+// SPDX-License-Identifier: MIT
+
+import { infiniteQueryOptions } from "@tanstack/react-query";
+import { fetchScans } from "./oshScans";
+
+export const oshScansQueryOptions = () =>
+  infiniteQueryOptions({
+    queryKey: ["openscanhub"],
+    queryFn: async ({ pageParam, signal }) =>
+      await fetchScans({ pageParam, signal }),
+    initialPageParam: 1,
+    getNextPageParam: (lastPage, _allPages, lastPageParam) => {
+      if (lastPage.length === 0) {
+        return undefined;
+      }
+      return lastPageParam + 1;
+    },
+    getPreviousPageParam: (_firstPage, _allPages, firstPageParam) => {
+      if (firstPageParam <= 1) {
+        return undefined;
+      }
+      return firstPageParam - 1;
+    },
+  });

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -30,6 +30,7 @@ import { Route as JobsPullFromUpstreamsImport } from './routes/jobs/pull-from-up
 import { Route as JobsPullFromUpstreamImport } from './routes/jobs/pull-from-upstream'
 import { Route as JobsProposeDownstreamsImport } from './routes/jobs/propose-downstreams'
 import { Route as JobsProposeDownstreamImport } from './routes/jobs/propose-downstream'
+import { Route as JobsOshScansImport } from './routes/jobs/osh-scans'
 import { Route as JobsKojiDownstreamImport } from './routes/jobs/koji-downstream'
 import { Route as JobsKojiBuildsImport } from './routes/jobs/koji-builds'
 import { Route as JobsKojiImport } from './routes/jobs/koji'
@@ -42,6 +43,7 @@ import { Route as JobsTestingFarmIdImport } from './routes/jobs_/testing-farm.$i
 import { Route as JobsSrpmIdImport } from './routes/jobs_/srpm.$id'
 import { Route as JobsPullFromUpstreamIdImport } from './routes/jobs_/pull-from-upstream.$id'
 import { Route as JobsProposeDownstreamIdImport } from './routes/jobs_/propose-downstream.$id'
+import { Route as JobsOshScansIdImport } from './routes/jobs_/osh-scans.$id'
 import { Route as JobsKojiIdImport } from './routes/jobs_/koji.$id'
 import { Route as JobsKojiDownstreamIdImport } from './routes/jobs_/koji-downstream.$id'
 import { Route as JobsCoprIdImport } from './routes/jobs_/copr.$id'
@@ -151,6 +153,11 @@ const JobsProposeDownstreamRoute = JobsProposeDownstreamImport.update({
   getParentRoute: () => JobsRoute,
 } as any)
 
+const JobsOshScansRoute = JobsOshScansImport.update({
+  path: '/osh-scans',
+  getParentRoute: () => JobsRoute,
+} as any)
+
 const JobsKojiDownstreamRoute = JobsKojiDownstreamImport.update({
   path: '/koji-downstream',
   getParentRoute: () => JobsRoute,
@@ -217,6 +224,11 @@ const JobsPullFromUpstreamIdRoute = JobsPullFromUpstreamIdImport.update({
 
 const JobsProposeDownstreamIdRoute = JobsProposeDownstreamIdImport.update({
   path: '/jobs/propose-downstream/$id',
+  getParentRoute: () => rootRoute,
+} as any)
+
+const JobsOshScansIdRoute = JobsOshScansIdImport.update({
+  path: '/jobs/osh-scans/$id',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -351,6 +363,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof JobsKojiDownstreamImport
       parentRoute: typeof JobsImport
     }
+    '/jobs/osh-scans': {
+      id: '/jobs/osh-scans'
+      path: '/osh-scans'
+      fullPath: '/jobs/osh-scans'
+      preLoaderRoute: typeof JobsOshScansImport
+      parentRoute: typeof JobsImport
+    }
     '/jobs/propose-downstream': {
       id: '/jobs/propose-downstream'
       path: '/propose-downstream'
@@ -463,6 +482,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof JobsKojiIdImport
       parentRoute: typeof rootRoute
     }
+    '/jobs/osh-scans/$id': {
+      id: '/jobs/osh-scans/$id'
+      path: '/jobs/osh-scans/$id'
+      fullPath: '/jobs/osh-scans/$id'
+      preLoaderRoute: typeof JobsOshScansIdImport
+      parentRoute: typeof rootRoute
+    }
     '/jobs/propose-downstream/$id': {
       id: '/jobs/propose-downstream/$id'
       path: '/jobs/propose-downstream/$id'
@@ -519,6 +545,7 @@ interface JobsRouteChildren {
   JobsKojiRoute: typeof JobsKojiRoute
   JobsKojiBuildsRoute: typeof JobsKojiBuildsRoute
   JobsKojiDownstreamRoute: typeof JobsKojiDownstreamRoute
+  JobsOshScansRoute: typeof JobsOshScansRoute
   JobsProposeDownstreamRoute: typeof JobsProposeDownstreamRoute
   JobsProposeDownstreamsRoute: typeof JobsProposeDownstreamsRoute
   JobsPullFromUpstreamRoute: typeof JobsPullFromUpstreamRoute
@@ -539,6 +566,7 @@ const JobsRouteChildren: JobsRouteChildren = {
   JobsKojiRoute: JobsKojiRoute,
   JobsKojiBuildsRoute: JobsKojiBuildsRoute,
   JobsKojiDownstreamRoute: JobsKojiDownstreamRoute,
+  JobsOshScansRoute: JobsOshScansRoute,
   JobsProposeDownstreamRoute: JobsProposeDownstreamRoute,
   JobsProposeDownstreamsRoute: JobsProposeDownstreamsRoute,
   JobsPullFromUpstreamRoute: JobsPullFromUpstreamRoute,
@@ -567,6 +595,7 @@ export interface FileRoutesByFullPath {
   '/jobs/koji': typeof JobsKojiRoute
   '/jobs/koji-builds': typeof JobsKojiBuildsRoute
   '/jobs/koji-downstream': typeof JobsKojiDownstreamRoute
+  '/jobs/osh-scans': typeof JobsOshScansRoute
   '/jobs/propose-downstream': typeof JobsProposeDownstreamRoute
   '/jobs/propose-downstreams': typeof JobsProposeDownstreamsRoute
   '/jobs/pull-from-upstream': typeof JobsPullFromUpstreamRoute
@@ -583,6 +612,7 @@ export interface FileRoutesByFullPath {
   '/jobs/copr/$id': typeof JobsCoprIdRoute
   '/jobs/koji-downstream/$id': typeof JobsKojiDownstreamIdRoute
   '/jobs/koji/$id': typeof JobsKojiIdRoute
+  '/jobs/osh-scans/$id': typeof JobsOshScansIdRoute
   '/jobs/propose-downstream/$id': typeof JobsProposeDownstreamIdRoute
   '/jobs/pull-from-upstream/$id': typeof JobsPullFromUpstreamIdRoute
   '/jobs/srpm/$id': typeof JobsSrpmIdRoute
@@ -605,6 +635,7 @@ export interface FileRoutesByTo {
   '/jobs/koji': typeof JobsKojiRoute
   '/jobs/koji-builds': typeof JobsKojiBuildsRoute
   '/jobs/koji-downstream': typeof JobsKojiDownstreamRoute
+  '/jobs/osh-scans': typeof JobsOshScansRoute
   '/jobs/propose-downstream': typeof JobsProposeDownstreamRoute
   '/jobs/propose-downstreams': typeof JobsProposeDownstreamsRoute
   '/jobs/pull-from-upstream': typeof JobsPullFromUpstreamRoute
@@ -621,6 +652,7 @@ export interface FileRoutesByTo {
   '/jobs/copr/$id': typeof JobsCoprIdRoute
   '/jobs/koji-downstream/$id': typeof JobsKojiDownstreamIdRoute
   '/jobs/koji/$id': typeof JobsKojiIdRoute
+  '/jobs/osh-scans/$id': typeof JobsOshScansIdRoute
   '/jobs/propose-downstream/$id': typeof JobsProposeDownstreamIdRoute
   '/jobs/pull-from-upstream/$id': typeof JobsPullFromUpstreamIdRoute
   '/jobs/srpm/$id': typeof JobsSrpmIdRoute
@@ -645,6 +677,7 @@ export interface FileRoutesById {
   '/jobs/koji': typeof JobsKojiRoute
   '/jobs/koji-builds': typeof JobsKojiBuildsRoute
   '/jobs/koji-downstream': typeof JobsKojiDownstreamRoute
+  '/jobs/osh-scans': typeof JobsOshScansRoute
   '/jobs/propose-downstream': typeof JobsProposeDownstreamRoute
   '/jobs/propose-downstreams': typeof JobsProposeDownstreamsRoute
   '/jobs/pull-from-upstream': typeof JobsPullFromUpstreamRoute
@@ -661,6 +694,7 @@ export interface FileRoutesById {
   '/jobs/copr/$id': typeof JobsCoprIdRoute
   '/jobs/koji-downstream/$id': typeof JobsKojiDownstreamIdRoute
   '/jobs/koji/$id': typeof JobsKojiIdRoute
+  '/jobs/osh-scans/$id': typeof JobsOshScansIdRoute
   '/jobs/propose-downstream/$id': typeof JobsProposeDownstreamIdRoute
   '/jobs/pull-from-upstream/$id': typeof JobsPullFromUpstreamIdRoute
   '/jobs/srpm/$id': typeof JobsSrpmIdRoute
@@ -686,6 +720,7 @@ export interface FileRouteTypes {
     | '/jobs/koji'
     | '/jobs/koji-builds'
     | '/jobs/koji-downstream'
+    | '/jobs/osh-scans'
     | '/jobs/propose-downstream'
     | '/jobs/propose-downstreams'
     | '/jobs/pull-from-upstream'
@@ -702,6 +737,7 @@ export interface FileRouteTypes {
     | '/jobs/copr/$id'
     | '/jobs/koji-downstream/$id'
     | '/jobs/koji/$id'
+    | '/jobs/osh-scans/$id'
     | '/jobs/propose-downstream/$id'
     | '/jobs/pull-from-upstream/$id'
     | '/jobs/srpm/$id'
@@ -723,6 +759,7 @@ export interface FileRouteTypes {
     | '/jobs/koji'
     | '/jobs/koji-builds'
     | '/jobs/koji-downstream'
+    | '/jobs/osh-scans'
     | '/jobs/propose-downstream'
     | '/jobs/propose-downstreams'
     | '/jobs/pull-from-upstream'
@@ -739,6 +776,7 @@ export interface FileRouteTypes {
     | '/jobs/copr/$id'
     | '/jobs/koji-downstream/$id'
     | '/jobs/koji/$id'
+    | '/jobs/osh-scans/$id'
     | '/jobs/propose-downstream/$id'
     | '/jobs/pull-from-upstream/$id'
     | '/jobs/srpm/$id'
@@ -761,6 +799,7 @@ export interface FileRouteTypes {
     | '/jobs/koji'
     | '/jobs/koji-builds'
     | '/jobs/koji-downstream'
+    | '/jobs/osh-scans'
     | '/jobs/propose-downstream'
     | '/jobs/propose-downstreams'
     | '/jobs/pull-from-upstream'
@@ -777,6 +816,7 @@ export interface FileRouteTypes {
     | '/jobs/copr/$id'
     | '/jobs/koji-downstream/$id'
     | '/jobs/koji/$id'
+    | '/jobs/osh-scans/$id'
     | '/jobs/propose-downstream/$id'
     | '/jobs/pull-from-upstream/$id'
     | '/jobs/srpm/$id'
@@ -800,6 +840,7 @@ export interface RootRouteChildren {
   JobsCoprIdRoute: typeof JobsCoprIdRoute
   JobsKojiDownstreamIdRoute: typeof JobsKojiDownstreamIdRoute
   JobsKojiIdRoute: typeof JobsKojiIdRoute
+  JobsOshScansIdRoute: typeof JobsOshScansIdRoute
   JobsProposeDownstreamIdRoute: typeof JobsProposeDownstreamIdRoute
   JobsPullFromUpstreamIdRoute: typeof JobsPullFromUpstreamIdRoute
   JobsSrpmIdRoute: typeof JobsSrpmIdRoute
@@ -822,6 +863,7 @@ const rootRouteChildren: RootRouteChildren = {
   JobsCoprIdRoute: JobsCoprIdRoute,
   JobsKojiDownstreamIdRoute: JobsKojiDownstreamIdRoute,
   JobsKojiIdRoute: JobsKojiIdRoute,
+  JobsOshScansIdRoute: JobsOshScansIdRoute,
   JobsProposeDownstreamIdRoute: JobsProposeDownstreamIdRoute,
   JobsPullFromUpstreamIdRoute: JobsPullFromUpstreamIdRoute,
   JobsSrpmIdRoute: JobsSrpmIdRoute,
@@ -855,6 +897,7 @@ export const routeTree = rootRoute
         "/jobs/copr/$id",
         "/jobs/koji-downstream/$id",
         "/jobs/koji/$id",
+        "/jobs/osh-scans/$id",
         "/jobs/propose-downstream/$id",
         "/jobs/pull-from-upstream/$id",
         "/jobs/srpm/$id",
@@ -877,6 +920,7 @@ export const routeTree = rootRoute
         "/jobs/koji",
         "/jobs/koji-builds",
         "/jobs/koji-downstream",
+        "/jobs/osh-scans",
         "/jobs/propose-downstream",
         "/jobs/propose-downstreams",
         "/jobs/pull-from-upstream",
@@ -930,6 +974,10 @@ export const routeTree = rootRoute
     },
     "/jobs/koji-downstream": {
       "filePath": "jobs/koji-downstream.tsx",
+      "parent": "/jobs"
+    },
+    "/jobs/osh-scans": {
+      "filePath": "jobs/osh-scans.tsx",
       "parent": "/jobs"
     },
     "/jobs/propose-downstream": {
@@ -988,6 +1036,9 @@ export const routeTree = rootRoute
     },
     "/jobs/koji/$id": {
       "filePath": "jobs_/koji.$id.tsx"
+    },
+    "/jobs/osh-scans/$id": {
+      "filePath": "jobs_/osh-scans.$id.tsx"
     },
     "/jobs/propose-downstream/$id": {
       "filePath": "jobs_/propose-downstream.$id.tsx"

--- a/frontend/src/routes/jobs/osh-scans.tsx
+++ b/frontend/src/routes/jobs/osh-scans.tsx
@@ -1,0 +1,12 @@
+// Copyright Contributors to the Packit project.
+// SPDX-License-Identifier: MIT
+
+import { createFileRoute, redirect } from "@tanstack/react-router";
+import { OSHScansTable } from "../../components/osh/OSHScansTable";
+
+export const Route = createFileRoute("/jobs/osh-scans")({
+  staticData: {
+    title: "OSH scan jobs",
+  },
+  component: () => OSHScansTable(),
+});

--- a/frontend/src/routes/jobs_/osh-scans.$id.tsx
+++ b/frontend/src/routes/jobs_/osh-scans.$id.tsx
@@ -1,0 +1,15 @@
+// Copyright Contributors to the Packit project.
+// SPDX-License-Identifier: MIT
+
+import { createFileRoute } from "@tanstack/react-router";
+import { OSHScan } from "../../components/osh/OSHScan";
+import { oshScanQueryOptions } from "../../queries/osh/oshScanQuery";
+
+export const Route = createFileRoute("/jobs/osh-scans/$id")({
+  staticData: {
+    title: "OSH scan job detail",
+  },
+  loader: ({ context: { queryClient }, params: { id } }) =>
+    queryClient.ensureQueryData(oshScanQueryOptions({ id })),
+  component: OSHScan,
+});


### PR DESCRIPTION
Related to #441 

![Snímka obrazovky z 2024-11-11 11-53-05](https://github.com/user-attachments/assets/a1f341f4-1729-4486-8b4f-62883e87fef4)
![Snímka obrazovky z 2024-11-11 11-52-47](https://github.com/user-attachments/assets/c0d9bcb4-938a-4b3d-ab8d-bf8a13360a1f)


RELEASE NOTES BEGIN

Dashboard now provides views for OpenScanHub scans.

RELEASE NOTES END
