### PR TITLE
Improve OpenScanHub URLs & ensured TypeScript compliance

### DIFF
--- a/frontend/src/apiDefinitions.ts
+++ b/frontend/src/apiDefinitions.ts
@@ -392,26 +392,27 @@ export interface PipelineRun {
 
 // /api/osh-scans
 export interface OSHScanGroup {
-  packit_id: number;
   anitya_package: string | null;
   anitya_project_id: number | null;
   anitya_project_name: string | null;
   anitya_version: string | null;
   branch_name: string | null;
   commit_sha: string;
+  copr_build_target_id: number;
+  issues_added_url: string;
+  issues_fixed_url: string;
   non_git_upstream: boolean;
+  packit_id: number;
   pr_id: number | null;
   project_url: string;
   release: string | null;
   repo_name: string;
   repo_namespace: string;
-  copr_build_target_id: number;
+  scan_results_url: string;
   status: string;
+  submitted_time: number | null;
   task_id: number;
   url: string;
-  issues_added_url: string;
-  issues_fixed_url: string;
-  scan_results_url: string;
 }
 
 // /api/osh-scans/$id
@@ -422,17 +423,18 @@ export interface OSHScan {
   anitya_version: string | null;
   branch_name: string | null;
   commit_sha: string;
+  copr_build_target_id: number;
+  issues_added_url: string;
+  issues_fixed_url: string;
   non_git_upstream: boolean;
   pr_id: number | null;
   project_url: string;
   release: string | null;
   repo_name: string;
   repo_namespace: string;
-  copr_build_target_id: number;
+  scan_results_url: string;
   status: string;
+  submitted_time: number | null;
   task_id: number;
   url: string;
-  issues_added_url: string;
-  issues_fixed_url: string;
-  scan_results_url: string;
 }

--- a/frontend/src/components/jobs/Jobs.tsx
+++ b/frontend/src/components/jobs/Jobs.tsx
@@ -61,8 +61,8 @@ const Jobs = () => {
           <NavItem isActive={!!matchRoute(jobTypeObject("bodhi"))}>
             <Link {...jobTypeObject("bodhi")}>Bodhi Updates</Link>
           </NavItem>
-          <NavItem isActive={!!matchRoute(jobTypeObject("osh-scans"))}>
-            <Link {...jobTypeObject("osh-scans")}>OpenScanHub Scans</Link>
+          <NavItem isActive={!!matchRoute(jobTypeObject("openscanhub"))}>
+            <Link {...jobTypeObject("openscanhub")}>OpenScanHub</Link>
           </NavItem>
         </NavList>
       </Nav>

--- a/frontend/src/components/osh/OSHScan.tsx
+++ b/frontend/src/components/osh/OSHScan.tsx
@@ -9,12 +9,14 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  List,
+  ListItem,
   PageSection,
   Title,
 } from "@patternfly/react-core";
 import { useQuery } from "@tanstack/react-query";
 import { oshScanQueryOptions } from "../../queries/osh/oshScanQuery";
-import { Route as OSHScanRoute } from "../../routes/jobs_/osh-scans.$id";
+import { Route as OSHScanRoute } from "../../routes/jobs_/openscanhub.$id";
 import { ErrorConnection } from "../errors/ErrorConnection";
 import { LabelLink } from "../shared/LabelLink";
 import { Preloader } from "../shared/Preloader";
@@ -91,33 +93,35 @@ export const OSHScan = () => {
                   <>
                     <DescriptionListTerm>Result files</DescriptionListTerm>
                     <DescriptionListDescription>
-                      <div>
-                        <a
-                          href={data.issues_added_url}
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          Added issues
-                        </a>
-                      </div>
-                      <div>
-                        <a
-                          href={data.issues_fixed_url}
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          Fixed issues
-                        </a>
-                      </div>
-                      <div>
-                        <a
-                          href={data.scan_results_url}
-                          rel="noreferrer"
-                          target="_blank"
-                        >
-                          All results
-                        </a>
-                      </div>
+                      <List>
+                        <ListItem>
+                          <a
+                            href={data.issues_added_url}
+                            rel="noreferrer"
+                            target="_blank"
+                          >
+                            Added issues
+                          </a>
+                        </ListItem>
+                        <ListItem>
+                          <a
+                            href={data.issues_fixed_url}
+                            rel="noreferrer"
+                            target="_blank"
+                          >
+                            Fixed issues
+                          </a>
+                        </ListItem>
+                        <ListItem>
+                          <a
+                            href={data.scan_results_url}
+                            rel="noreferrer"
+                            target="_blank"
+                          >
+                            All results
+                          </a>
+                        </ListItem>
+                      </List>
                     </DescriptionListDescription>
                   </>
                 ) : (

--- a/frontend/src/components/osh/OSHScansTable.tsx
+++ b/frontend/src/components/osh/OSHScansTable.tsx
@@ -22,7 +22,7 @@ import {
   TriggerSuffix,
 } from "../../components/trigger/TriggerLink";
 import { oshScansQueryOptions } from "../../queries/osh/oshScansQuery";
-import { ForgeIcon, ForgeIconByForge } from "../icons/ForgeIcon";
+import { ForgeIcon } from "../icons/ForgeIcon";
 import { LoadMore } from "../shared/LoadMore";
 import { StatusLabel } from "../statusLabels/StatusLabel";
 
@@ -31,9 +31,9 @@ const OSHScansTable = () => {
   const columnNames = {
     forge: "Forge",
     trigger: "Trigger",
-    scan: "OpenScanHub task",
-    branch: "Scan details",
+    scanDetails: "Scan details",
     timeProcessed: "Time Processed",
+    scan: "OpenScanHub task",
   };
 
   const {
@@ -55,8 +55,8 @@ const OSHScansTable = () => {
     <Th key={columnNames.trigger} width={35}>
       {columnNames.trigger}
     </Th>,
-    <Th key={columnNames.branch} width={20}>
-      {columnNames.branch}
+    <Th key={columnNames.scanDetails} width={20}>
+      {columnNames.scanDetails}
     </Th>,
     <Th key={columnNames.timeProcessed} width={20}>
       {columnNames.timeProcessed}
@@ -75,7 +75,7 @@ const OSHScansTable = () => {
     return (
       <SkeletonTable
         variant={TableVariant.compact}
-        rows={10}
+        rowsCount={10}
         columns={TableHeads}
       />
     );
@@ -100,17 +100,17 @@ const OSHScansTable = () => {
                   </TriggerLink>
                 </strong>
               </Td>
-              <Td dataLabel={columnNames.branch}>
+              <Td dataLabel={columnNames.scanDetails}>
                 <StatusLabel
                   target={"rawhide"}
                   status={scan.status}
-                  link={`/jobs/osh-scans/${scan.packit_id}`}
+                  link={`/jobs/openscanhub/${scan.packit_id}`}
                 />
               </Td>
               <Td dataLabel={columnNames.timeProcessed}>
                 <Timestamp stamp={scan.submitted_time} />
               </Td>
-              <Td dataLabel={columnNames.bodhiUpdate}>
+              <Td dataLabel={columnNames.scan}>
                 <strong>
                   <a href={scan.url ?? ""} target="_blank" rel="noreferrer">
                     {scan.task_id}

--- a/frontend/src/routeTree.gen.ts
+++ b/frontend/src/routeTree.gen.ts
@@ -30,7 +30,7 @@ import { Route as JobsPullFromUpstreamsImport } from './routes/jobs/pull-from-up
 import { Route as JobsPullFromUpstreamImport } from './routes/jobs/pull-from-upstream'
 import { Route as JobsProposeDownstreamsImport } from './routes/jobs/propose-downstreams'
 import { Route as JobsProposeDownstreamImport } from './routes/jobs/propose-downstream'
-import { Route as JobsOshScansImport } from './routes/jobs/osh-scans'
+import { Route as JobsOpenscanhubImport } from './routes/jobs/openscanhub'
 import { Route as JobsKojiDownstreamImport } from './routes/jobs/koji-downstream'
 import { Route as JobsKojiBuildsImport } from './routes/jobs/koji-builds'
 import { Route as JobsKojiImport } from './routes/jobs/koji'
@@ -43,7 +43,7 @@ import { Route as JobsTestingFarmIdImport } from './routes/jobs_/testing-farm.$i
 import { Route as JobsSrpmIdImport } from './routes/jobs_/srpm.$id'
 import { Route as JobsPullFromUpstreamIdImport } from './routes/jobs_/pull-from-upstream.$id'
 import { Route as JobsProposeDownstreamIdImport } from './routes/jobs_/propose-downstream.$id'
-import { Route as JobsOshScansIdImport } from './routes/jobs_/osh-scans.$id'
+import { Route as JobsOpenscanhubIdImport } from './routes/jobs_/openscanhub.$id'
 import { Route as JobsKojiIdImport } from './routes/jobs_/koji.$id'
 import { Route as JobsKojiDownstreamIdImport } from './routes/jobs_/koji-downstream.$id'
 import { Route as JobsCoprIdImport } from './routes/jobs_/copr.$id'
@@ -153,8 +153,8 @@ const JobsProposeDownstreamRoute = JobsProposeDownstreamImport.update({
   getParentRoute: () => JobsRoute,
 } as any)
 
-const JobsOshScansRoute = JobsOshScansImport.update({
-  path: '/osh-scans',
+const JobsOpenscanhubRoute = JobsOpenscanhubImport.update({
+  path: '/openscanhub',
   getParentRoute: () => JobsRoute,
 } as any)
 
@@ -227,8 +227,8 @@ const JobsProposeDownstreamIdRoute = JobsProposeDownstreamIdImport.update({
   getParentRoute: () => rootRoute,
 } as any)
 
-const JobsOshScansIdRoute = JobsOshScansIdImport.update({
-  path: '/jobs/osh-scans/$id',
+const JobsOpenscanhubIdRoute = JobsOpenscanhubIdImport.update({
+  path: '/jobs/openscanhub/$id',
   getParentRoute: () => rootRoute,
 } as any)
 
@@ -363,11 +363,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof JobsKojiDownstreamImport
       parentRoute: typeof JobsImport
     }
-    '/jobs/osh-scans': {
-      id: '/jobs/osh-scans'
-      path: '/osh-scans'
-      fullPath: '/jobs/osh-scans'
-      preLoaderRoute: typeof JobsOshScansImport
+    '/jobs/openscanhub': {
+      id: '/jobs/openscanhub'
+      path: '/openscanhub'
+      fullPath: '/jobs/openscanhub'
+      preLoaderRoute: typeof JobsOpenscanhubImport
       parentRoute: typeof JobsImport
     }
     '/jobs/propose-downstream': {
@@ -482,11 +482,11 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof JobsKojiIdImport
       parentRoute: typeof rootRoute
     }
-    '/jobs/osh-scans/$id': {
-      id: '/jobs/osh-scans/$id'
-      path: '/jobs/osh-scans/$id'
-      fullPath: '/jobs/osh-scans/$id'
-      preLoaderRoute: typeof JobsOshScansIdImport
+    '/jobs/openscanhub/$id': {
+      id: '/jobs/openscanhub/$id'
+      path: '/jobs/openscanhub/$id'
+      fullPath: '/jobs/openscanhub/$id'
+      preLoaderRoute: typeof JobsOpenscanhubIdImport
       parentRoute: typeof rootRoute
     }
     '/jobs/propose-downstream/$id': {
@@ -545,7 +545,7 @@ interface JobsRouteChildren {
   JobsKojiRoute: typeof JobsKojiRoute
   JobsKojiBuildsRoute: typeof JobsKojiBuildsRoute
   JobsKojiDownstreamRoute: typeof JobsKojiDownstreamRoute
-  JobsOshScansRoute: typeof JobsOshScansRoute
+  JobsOpenscanhubRoute: typeof JobsOpenscanhubRoute
   JobsProposeDownstreamRoute: typeof JobsProposeDownstreamRoute
   JobsProposeDownstreamsRoute: typeof JobsProposeDownstreamsRoute
   JobsPullFromUpstreamRoute: typeof JobsPullFromUpstreamRoute
@@ -566,7 +566,7 @@ const JobsRouteChildren: JobsRouteChildren = {
   JobsKojiRoute: JobsKojiRoute,
   JobsKojiBuildsRoute: JobsKojiBuildsRoute,
   JobsKojiDownstreamRoute: JobsKojiDownstreamRoute,
-  JobsOshScansRoute: JobsOshScansRoute,
+  JobsOpenscanhubRoute: JobsOpenscanhubRoute,
   JobsProposeDownstreamRoute: JobsProposeDownstreamRoute,
   JobsProposeDownstreamsRoute: JobsProposeDownstreamsRoute,
   JobsPullFromUpstreamRoute: JobsPullFromUpstreamRoute,
@@ -595,7 +595,7 @@ export interface FileRoutesByFullPath {
   '/jobs/koji': typeof JobsKojiRoute
   '/jobs/koji-builds': typeof JobsKojiBuildsRoute
   '/jobs/koji-downstream': typeof JobsKojiDownstreamRoute
-  '/jobs/osh-scans': typeof JobsOshScansRoute
+  '/jobs/openscanhub': typeof JobsOpenscanhubRoute
   '/jobs/propose-downstream': typeof JobsProposeDownstreamRoute
   '/jobs/propose-downstreams': typeof JobsProposeDownstreamsRoute
   '/jobs/pull-from-upstream': typeof JobsPullFromUpstreamRoute
@@ -612,7 +612,7 @@ export interface FileRoutesByFullPath {
   '/jobs/copr/$id': typeof JobsCoprIdRoute
   '/jobs/koji-downstream/$id': typeof JobsKojiDownstreamIdRoute
   '/jobs/koji/$id': typeof JobsKojiIdRoute
-  '/jobs/osh-scans/$id': typeof JobsOshScansIdRoute
+  '/jobs/openscanhub/$id': typeof JobsOpenscanhubIdRoute
   '/jobs/propose-downstream/$id': typeof JobsProposeDownstreamIdRoute
   '/jobs/pull-from-upstream/$id': typeof JobsPullFromUpstreamIdRoute
   '/jobs/srpm/$id': typeof JobsSrpmIdRoute
@@ -635,7 +635,7 @@ export interface FileRoutesByTo {
   '/jobs/koji': typeof JobsKojiRoute
   '/jobs/koji-builds': typeof JobsKojiBuildsRoute
   '/jobs/koji-downstream': typeof JobsKojiDownstreamRoute
-  '/jobs/osh-scans': typeof JobsOshScansRoute
+  '/jobs/openscanhub': typeof JobsOpenscanhubRoute
   '/jobs/propose-downstream': typeof JobsProposeDownstreamRoute
   '/jobs/propose-downstreams': typeof JobsProposeDownstreamsRoute
   '/jobs/pull-from-upstream': typeof JobsPullFromUpstreamRoute
@@ -652,7 +652,7 @@ export interface FileRoutesByTo {
   '/jobs/copr/$id': typeof JobsCoprIdRoute
   '/jobs/koji-downstream/$id': typeof JobsKojiDownstreamIdRoute
   '/jobs/koji/$id': typeof JobsKojiIdRoute
-  '/jobs/osh-scans/$id': typeof JobsOshScansIdRoute
+  '/jobs/openscanhub/$id': typeof JobsOpenscanhubIdRoute
   '/jobs/propose-downstream/$id': typeof JobsProposeDownstreamIdRoute
   '/jobs/pull-from-upstream/$id': typeof JobsPullFromUpstreamIdRoute
   '/jobs/srpm/$id': typeof JobsSrpmIdRoute
@@ -677,7 +677,7 @@ export interface FileRoutesById {
   '/jobs/koji': typeof JobsKojiRoute
   '/jobs/koji-builds': typeof JobsKojiBuildsRoute
   '/jobs/koji-downstream': typeof JobsKojiDownstreamRoute
-  '/jobs/osh-scans': typeof JobsOshScansRoute
+  '/jobs/openscanhub': typeof JobsOpenscanhubRoute
   '/jobs/propose-downstream': typeof JobsProposeDownstreamRoute
   '/jobs/propose-downstreams': typeof JobsProposeDownstreamsRoute
   '/jobs/pull-from-upstream': typeof JobsPullFromUpstreamRoute
@@ -694,7 +694,7 @@ export interface FileRoutesById {
   '/jobs/copr/$id': typeof JobsCoprIdRoute
   '/jobs/koji-downstream/$id': typeof JobsKojiDownstreamIdRoute
   '/jobs/koji/$id': typeof JobsKojiIdRoute
-  '/jobs/osh-scans/$id': typeof JobsOshScansIdRoute
+  '/jobs/openscanhub/$id': typeof JobsOpenscanhubIdRoute
   '/jobs/propose-downstream/$id': typeof JobsProposeDownstreamIdRoute
   '/jobs/pull-from-upstream/$id': typeof JobsPullFromUpstreamIdRoute
   '/jobs/srpm/$id': typeof JobsSrpmIdRoute
@@ -720,7 +720,7 @@ export interface FileRouteTypes {
     | '/jobs/koji'
     | '/jobs/koji-builds'
     | '/jobs/koji-downstream'
-    | '/jobs/osh-scans'
+    | '/jobs/openscanhub'
     | '/jobs/propose-downstream'
     | '/jobs/propose-downstreams'
     | '/jobs/pull-from-upstream'
@@ -737,7 +737,7 @@ export interface FileRouteTypes {
     | '/jobs/copr/$id'
     | '/jobs/koji-downstream/$id'
     | '/jobs/koji/$id'
-    | '/jobs/osh-scans/$id'
+    | '/jobs/openscanhub/$id'
     | '/jobs/propose-downstream/$id'
     | '/jobs/pull-from-upstream/$id'
     | '/jobs/srpm/$id'
@@ -759,7 +759,7 @@ export interface FileRouteTypes {
     | '/jobs/koji'
     | '/jobs/koji-builds'
     | '/jobs/koji-downstream'
-    | '/jobs/osh-scans'
+    | '/jobs/openscanhub'
     | '/jobs/propose-downstream'
     | '/jobs/propose-downstreams'
     | '/jobs/pull-from-upstream'
@@ -776,7 +776,7 @@ export interface FileRouteTypes {
     | '/jobs/copr/$id'
     | '/jobs/koji-downstream/$id'
     | '/jobs/koji/$id'
-    | '/jobs/osh-scans/$id'
+    | '/jobs/openscanhub/$id'
     | '/jobs/propose-downstream/$id'
     | '/jobs/pull-from-upstream/$id'
     | '/jobs/srpm/$id'
@@ -799,7 +799,7 @@ export interface FileRouteTypes {
     | '/jobs/koji'
     | '/jobs/koji-builds'
     | '/jobs/koji-downstream'
-    | '/jobs/osh-scans'
+    | '/jobs/openscanhub'
     | '/jobs/propose-downstream'
     | '/jobs/propose-downstreams'
     | '/jobs/pull-from-upstream'
@@ -816,7 +816,7 @@ export interface FileRouteTypes {
     | '/jobs/copr/$id'
     | '/jobs/koji-downstream/$id'
     | '/jobs/koji/$id'
-    | '/jobs/osh-scans/$id'
+    | '/jobs/openscanhub/$id'
     | '/jobs/propose-downstream/$id'
     | '/jobs/pull-from-upstream/$id'
     | '/jobs/srpm/$id'
@@ -840,7 +840,7 @@ export interface RootRouteChildren {
   JobsCoprIdRoute: typeof JobsCoprIdRoute
   JobsKojiDownstreamIdRoute: typeof JobsKojiDownstreamIdRoute
   JobsKojiIdRoute: typeof JobsKojiIdRoute
-  JobsOshScansIdRoute: typeof JobsOshScansIdRoute
+  JobsOpenscanhubIdRoute: typeof JobsOpenscanhubIdRoute
   JobsProposeDownstreamIdRoute: typeof JobsProposeDownstreamIdRoute
   JobsPullFromUpstreamIdRoute: typeof JobsPullFromUpstreamIdRoute
   JobsSrpmIdRoute: typeof JobsSrpmIdRoute
@@ -863,7 +863,7 @@ const rootRouteChildren: RootRouteChildren = {
   JobsCoprIdRoute: JobsCoprIdRoute,
   JobsKojiDownstreamIdRoute: JobsKojiDownstreamIdRoute,
   JobsKojiIdRoute: JobsKojiIdRoute,
-  JobsOshScansIdRoute: JobsOshScansIdRoute,
+  JobsOpenscanhubIdRoute: JobsOpenscanhubIdRoute,
   JobsProposeDownstreamIdRoute: JobsProposeDownstreamIdRoute,
   JobsPullFromUpstreamIdRoute: JobsPullFromUpstreamIdRoute,
   JobsSrpmIdRoute: JobsSrpmIdRoute,
@@ -897,7 +897,7 @@ export const routeTree = rootRoute
         "/jobs/copr/$id",
         "/jobs/koji-downstream/$id",
         "/jobs/koji/$id",
-        "/jobs/osh-scans/$id",
+        "/jobs/openscanhub/$id",
         "/jobs/propose-downstream/$id",
         "/jobs/pull-from-upstream/$id",
         "/jobs/srpm/$id",
@@ -920,7 +920,7 @@ export const routeTree = rootRoute
         "/jobs/koji",
         "/jobs/koji-builds",
         "/jobs/koji-downstream",
-        "/jobs/osh-scans",
+        "/jobs/openscanhub",
         "/jobs/propose-downstream",
         "/jobs/propose-downstreams",
         "/jobs/pull-from-upstream",
@@ -976,8 +976,8 @@ export const routeTree = rootRoute
       "filePath": "jobs/koji-downstream.tsx",
       "parent": "/jobs"
     },
-    "/jobs/osh-scans": {
-      "filePath": "jobs/osh-scans.tsx",
+    "/jobs/openscanhub": {
+      "filePath": "jobs/openscanhub.tsx",
       "parent": "/jobs"
     },
     "/jobs/propose-downstream": {
@@ -1037,8 +1037,8 @@ export const routeTree = rootRoute
     "/jobs/koji/$id": {
       "filePath": "jobs_/koji.$id.tsx"
     },
-    "/jobs/osh-scans/$id": {
-      "filePath": "jobs_/osh-scans.$id.tsx"
+    "/jobs/openscanhub/$id": {
+      "filePath": "jobs_/openscanhub.$id.tsx"
     },
     "/jobs/propose-downstream/$id": {
       "filePath": "jobs_/propose-downstream.$id.tsx"

--- a/frontend/src/routes/jobs/openscanhub.tsx
+++ b/frontend/src/routes/jobs/openscanhub.tsx
@@ -1,12 +1,12 @@
 // Copyright Contributors to the Packit project.
 // SPDX-License-Identifier: MIT
 
-import { createFileRoute, redirect } from "@tanstack/react-router";
+import { createFileRoute } from "@tanstack/react-router";
 import { OSHScansTable } from "../../components/osh/OSHScansTable";
 
-export const Route = createFileRoute("/jobs/osh-scans")({
+export const Route = createFileRoute("/jobs/openscanhub")({
   staticData: {
-    title: "OSH scan jobs",
+    title: "OpenScanHub jobs",
   },
   component: () => OSHScansTable(),
 });

--- a/frontend/src/routes/jobs_/openscanhub.$id.tsx
+++ b/frontend/src/routes/jobs_/openscanhub.$id.tsx
@@ -5,9 +5,9 @@ import { createFileRoute } from "@tanstack/react-router";
 import { OSHScan } from "../../components/osh/OSHScan";
 import { oshScanQueryOptions } from "../../queries/osh/oshScanQuery";
 
-export const Route = createFileRoute("/jobs/osh-scans/$id")({
+export const Route = createFileRoute("/jobs/openscanhub/$id")({
   staticData: {
-    title: "OSH scan job detail",
+    title: "OpenScanHub job detail",
   },
   loader: ({ context: { queryClient }, params: { id } }) =>
     queryClient.ensureQueryData(oshScanQueryOptions({ id })),


### PR DESCRIPTION
There were some stuff missing regarding styling of the API and what went
on within components. In particular a lot of additions that were not
changed after copying from another component.

As for the API interfaces they were missing the submitted_time which
showed errors within the components themselves.

Also URLs and titles have been renamed to indicate OpenScanHub more
explicitly as we do not have to use abbreviations.

RELEASE NOTES BEGIN
Rename OpenScanHub URLs and improved styling
RELEASE NOTES END
