### PR TITLE
chore: Update pnpm cache location

### DIFF
--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           node-version: "20"
           cache: "pnpm"
-          cache-dependency-path: frontend/pnpm-lock.yaml
+          cache-dependency-path: pnpm-lock.yaml
 
       # Yes, we really need to get the PR changes
       - name: Get the PR changes


### PR DESCRIPTION
With the removal of an unused pnpm-lock with workspaces the workflow started to fail as it doesn't use the newer file location.

RELEASE NOTES BEGIN
Fixed PR preview yet again
RELEASE NOTES END
