### PR TITLE
fix(Copr): Handle `built_packages` being null

### DIFF
--- a/frontend/src/apiDefinitions.ts
+++ b/frontend/src/apiDefinitions.ts
@@ -112,7 +112,7 @@ export interface CoprBuild {
   build_logs_url: string;
   build_start_time: number;
   build_submitted_time: number;
-  built_packages: CoprBuildPackage[];
+  built_packages: CoprBuildPackage[] | null;
   chroot: string;
   commit_sha: string;
   copr_owner: string;

--- a/frontend/src/components/copr/CoprBuild.tsx
+++ b/frontend/src/components/copr/CoprBuild.tsx
@@ -36,7 +36,8 @@ export const CoprBuild = () => {
   const [packagesToInstall, setPackagesToInstall] = useState<string[]>([]);
 
   useEffect(() => {
-    if (data) setPackagesToInstall(getPackagesToInstall(data.built_packages));
+    if (data?.built_packages)
+      setPackagesToInstall(getPackagesToInstall(data.built_packages));
   }, [data?.built_packages]);
 
   // If backend API is down


### PR DESCRIPTION
The API definition did not take `null` for `built_packages` and thus never showed an issue with the code. This change fixes both the type and the issue itself.

Fixes #491 

RELEASE NOTES BEGIN
Fix Copr page crashing due to `built_packages` being `null`
RELEASE NOTES END
