### PR TITLE
Adjust to API changes for sync release runs

### DIFF
--- a/frontend/src/apiDefinitions.ts
+++ b/frontend/src/apiDefinitions.ts
@@ -371,6 +371,13 @@ export interface SyncReleaseJobGroup {
   submitted_time: number;
 }
 
+export interface DownstreamPR {
+  pr_id: number;
+  branch: string;
+  is_fast_forward: boolean;
+  url: string;
+}
+
 // /api/propose-downstream/$id
 // /api/pull-from-upstream/$id
 export interface SyncReleaseJob {
@@ -380,9 +387,8 @@ export interface SyncReleaseJob {
   anitya_version: string | null;
   branch: string;
   branch_name: string | null;
-  downstream_pr_id: number | null;
+  downstream_prs: DownstreamPR[];
   downstream_pr_project: string | null;
-  downstream_pr_url: string;
   finished_time: number;
   issue_id: number | null;
   logs: string;

--- a/frontend/src/components/sync-release/SyncRelease.tsx
+++ b/frontend/src/components/sync-release/SyncRelease.tsx
@@ -140,6 +140,15 @@ export const SyncRelease: React.FC<SyncReleaseProps> = ({ job }) => {
     }
   };
 
+  const targetStatusLabels = data.downstream_prs.map((pr) => (
+    <SyncReleaseTargetStatusLabel
+      key={pr.pr_id}
+      status={data.status}
+      target={pr.branch}
+      link={pr.url}
+    />
+  ));
+
   // TODO(SpyTec): Move to its own component
   const logs = (
     <PageSection hasBodyWrapper={false}>
@@ -266,11 +275,7 @@ export const SyncRelease: React.FC<SyncReleaseProps> = ({ job }) => {
               <DescriptionListGroup>
                 <DescriptionListTerm>Sync status</DescriptionListTerm>
                 <DescriptionListDescription>
-                  <SyncReleaseTargetStatusLabel
-                    status={data.status}
-                    target={data.branch}
-                    link={data.downstream_pr_url}
-                  />
+                  {targetStatusLabels}
                 </DescriptionListDescription>
                 <DescriptionListTerm>Package</DescriptionListTerm>
                 <DescriptionListDescription>


### PR DESCRIPTION
API now exposes mutliple downstream PRs in the response for sync release target detail that reflects the changes around fast forward PR creation.

Follow-up of packit/packit-service#2751

RELEASE NOTES BEGIN

Dashboard now displays links to all downstream pull requests created for release sync when using `fast_forward_merge_into` configuration.

RELEASE NOTES END