### PR TITLE
fix(project-search): make search button of type submit

### DIFF
--- a/frontend/src/components/projects/ProjectSearch.tsx
+++ b/frontend/src/components/projects/ProjectSearch.tsx
@@ -114,6 +114,7 @@ const ProjectSearch = () => {
               <InputGroupItem>
                 <Button
                   icon={<SearchIcon />}
+                  type="submit"
                   variant="plain"
                   aria-label="Search"
                   onClick={goToProjectDetails}


### PR DESCRIPTION
This commit should fix the problem when searching for projects by pressing Enter, doesn't work.

<!-- release notes footer -->

RELEASE NOTES BEGIN

You can now search projects on our dashboard by pressing Enter. 🕵️ 

RELEASE NOTES END
