### PR TITLE
Renaming build_submitted_time fields to submitted_time

### DIFF
--- a/frontend/src/apiDefinitions.ts
+++ b/frontend/src/apiDefinitions.ts
@@ -72,7 +72,7 @@ export interface ProjectPRs {
 export interface CoprBuildGroup {
   branch_name: string | null;
   build_id: number;
-  build_submitted_time: number;
+  submitted_time: number;
   packit_id: number;
   packit_id_per_chroot: {
     [key: string]: number;
@@ -111,7 +111,7 @@ export interface CoprBuild {
   build_id: string;
   build_logs_url: string;
   build_start_time: number;
-  build_submitted_time: number;
+  submitted_time: number;
   built_packages: CoprBuildPackage[] | null;
   chroot: string;
   commit_sha: string;
@@ -134,7 +134,7 @@ export interface CoprBuild {
 export interface KojiBuildGroup {
   branch_name: string | null;
   build_logs_urls: string;
-  build_submitted_time: number;
+  submitted_time: number;
   chroot: string;
   packit_id: number;
   // TODO: @Venefilyn - change interface depending on status of pr_id or branch_item.
@@ -160,7 +160,7 @@ export interface KojiBuild {
   build_finished_time: number;
   build_logs_urls: [string: string];
   build_start_time: number;
-  build_submitted_time: number;
+  submitted_time: number;
   chroot: string;
   commit_sha: string;
   issue_id: number | null;
@@ -230,7 +230,7 @@ export interface KojiTagRequest {
 // /api/srpm-builds
 export interface SRPMBuildGroup {
   branch_name: string | null;
-  build_submitted_time: number;
+  submitted_time: number;
   log_url: string;
   // TODO: @Venefilyn - change interface depending on status of pr_id or branch_item.
   // They seem to be mutually exclusive so can be sure one is null and other is string
@@ -251,7 +251,7 @@ export interface SRPMBuild {
   branch_name: string | null;
   build_finished_time: number;
   build_start_time: number;
-  build_submitted_time: number;
+  submitted_time: number;
   copr_build_id: string;
   copr_web_url: string;
   issue_id: number | null;

--- a/frontend/src/components/copr/CoprBuildDetail.tsx
+++ b/frontend/src/components/copr/CoprBuildDetail.tsx
@@ -77,7 +77,7 @@ export const CoprBuildDetail: React.FC<CoprBuildDetailProps> = ({ data }) => {
         </DescriptionListTerm>
         <DescriptionListDescription>
           <ResultProgressStep
-            submittedTime={data.build_submitted_time}
+            submittedTime={data.submitted_time}
             startTime={data.build_start_time}
             finishedTime={data.build_finished_time}
             status={getCoprBuildStatus(data.status)}

--- a/frontend/src/components/copr/CoprBuildsTable.tsx
+++ b/frontend/src/components/copr/CoprBuildsTable.tsx
@@ -119,7 +119,7 @@ const CoprBuildsTable = () => {
                   />
                 </Td>
                 <Td dataLabel={columnNames.timeSubmitted}>
-                  <Timestamp stamp={copr_build.build_submitted_time} />
+                  <Timestamp stamp={copr_build.submitted_time} />
                 </Td>
                 <Td dataLabel={columnNames.coprBuild}>
                   <strong>

--- a/frontend/src/components/koji/KojiBuild.tsx
+++ b/frontend/src/components/koji/KojiBuild.tsx
@@ -181,7 +181,7 @@ export const KojiBuild = () => {
                 </DescriptionListTerm>
                 <DescriptionListDescription>
                   <ResultProgressStep
-                    submittedTime={data.build_submitted_time}
+                    submittedTime={data.submitted_time}
                     startTime={data.build_start_time}
                     finishedTime={data.build_finished_time}
                     status={getKojiBuildStatus(data.status)}

--- a/frontend/src/components/koji/KojiBuildsTable.tsx
+++ b/frontend/src/components/koji/KojiBuildsTable.tsx
@@ -98,7 +98,7 @@ export const KojiBuildsTable: React.FC<KojiBuildTableProps> = ({ scratch }) => {
                   />
                 </Td>
                 <Td dataLabel={columnNames.timeSubmitted}>
-                  <Timestamp stamp={koji_build.build_submitted_time} />
+                  <Timestamp stamp={koji_build.submitted_time} />
                 </Td>
                 <Td dataLabel={columnNames.kojiBuildTask}>
                   <strong>

--- a/frontend/src/components/srpm/SRPMBuild.tsx
+++ b/frontend/src/components/srpm/SRPMBuild.tsx
@@ -149,7 +149,7 @@ export const SRPMBuild = () => {
                 </DescriptionListTerm>
                 <DescriptionListDescription>
                   <ResultProgressStep
-                    submittedTime={data.build_submitted_time}
+                    submittedTime={data.submitted_time}
                     startTime={data.build_start_time}
                     finishedTime={data.build_finished_time}
                     status={getSRPMStatus(data.status)}

--- a/frontend/src/components/srpm/SRPMBuildsTable.tsx
+++ b/frontend/src/components/srpm/SRPMBuildsTable.tsx
@@ -93,7 +93,7 @@ export const SRPMBuildsTable = () => {
                   />
                 </Td>
                 <Td dataLabel={columnNames.timeSubmitted}>
-                  <Timestamp stamp={srpm_build.build_submitted_time} />
+                  <Timestamp stamp={srpm_build.submitted_time} />
                 </Td>
               </Tr>
             ))}


### PR DESCRIPTION
Merge before/after

https://github.com/packit/packit-service/pull/2979

RELEASE NOTES BEGIN

The build_submitted_time of responses from following API endpoints has been renamed to submitted_time.

    copr-builds
    copr-builds/int:id
    koji-builds
    koji-builds/int:id
    srpm-builds
    srpm-builds/int:id

RELEASE NOTES END
