### PR TITLE
Pin GitHub Actions to commit hashes for security

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -17,7 +17,7 @@ jobs:
             image: dashboard
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Extract branch name and set tag
         shell: bash
@@ -50,7 +50,7 @@ jobs:
       - name: Build Image
         id: build-image
         # https://github.com/marketplace/actions/buildah-build
-        uses: redhat-actions/buildah-build@v2
+        uses: redhat-actions/buildah-build@7a95fa7ee0f02d552a32753e7414641a04307056 # v2
         with:
           dockerfiles: ${{ matrix.dockerfile }}
           image: ${{ matrix.image }}
@@ -64,7 +64,7 @@ jobs:
 
       - name: Push To Quay
         # https://github.com/marketplace/actions/push-to-registry
-        uses: redhat-actions/push-to-registry@v2
+        uses: redhat-actions/push-to-registry@5ed88d269cf581ea9ef6dd6806d01562096bee9c # v2
         with:
           image: ${{ steps.build-image.outputs.image }}
           tags: ${{ steps.build-image.outputs.tags }}

--- a/.github/workflows/check-release-notes.yml
+++ b/.github/workflows/check-release-notes.yml
@@ -10,6 +10,6 @@ on:
 jobs:
   check_release_notes:
     name: Notes are either written, or there are none
-    uses: packit/.github/.github/workflows/check-release-notes.yml@main
+    uses: packit/.github/.github/workflows/check-release-notes.yml@2837c96caf71966609451ad0323552ef4be11a23 # main
     with:
       description: ${{ github.event.pull_request.body }}

--- a/.github/workflows/opened-prs-to-the-board.yml
+++ b/.github/workflows/opened-prs-to-the-board.yml
@@ -8,7 +8,7 @@ jobs:
     if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/add-to-project@v0.3.0
+      - uses: actions/add-to-project@a9f041ddd462ed185893ea1024cec954f50dbe42 # v0.3.0
         with:
           project-url: https://github.com/orgs/packit/projects/14
           github-token: ${{ secrets.RELEASEBOT_GITHUB_TOKEN }}

--- a/.github/workflows/preview-pr.yml
+++ b/.github/workflows/preview-pr.yml
@@ -21,14 +21,14 @@ jobs:
       GH_PR_NUM: ${{ github.event.inputs.pr_id || github.event.number }}
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 9
           run_install: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "pnpm"

--- a/.github/workflows/test-frontend.yml
+++ b/.github/workflows/test-frontend.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@f40ffcd9367d9f12939873eb1018b921a783ffaa # v4
         with:
           version: 9
           run_install: false
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "pnpm"


### PR DESCRIPTION
Pin all actions to specific commit SHAs to prevent supply chain attacks and ensure reproducible builds.

Assisted-By: Claude Sonnet 4.5 <noreply@anthropic.com>