### PR TITLE
Add pyproject.toml for Python dependency management

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,7 +11,12 @@ Please follow common guidelines for our projects [here](https://github.com/packi
 
 ### Dependencies
 
-`make install-dependencies` automatically installs python dependencies and `pnpm`.
+Python dependencies are declared in `pyproject.toml` and can be installed either via system packages or pip.
+
+For local development, you can either:
+- Use `make install-dependencies` to install system packages (Fedora/RHEL)
+- Use `pip install -e .` to install in a virtual environment (see README.md for details)
+
 In case the `pnpm` installation fails, follow [this](https://pnpm.io/installation) guide for
 different installation options.
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,32 @@ for [the staging instance](https://dashboard.stg.packit.dev)).
 
 ### Running the dashboard locally
 
+#### Option 1: Using system packages (Fedora/RHEL)
+
 ```bash
 # install dependencies
 :~/dashboard $ make install-dependencies
 ```
+
+#### Option 2: Using pip/virtualenv
+
+```bash
+# create a virtual environment (optional but recommended)
+:~/dashboard $ python3 -m venv venv
+:~/dashboard $ source venv/bin/activate
+
+# install the package with dependencies
+:~/dashboard $ pip install -e .
+
+# install test dependencies (if running tests)
+:~/dashboard $ pip install -e '.[testing]'
+
+# install pnpm and frontend dependencies
+:~/dashboard $ sudo dnf install pnpm
+:~/dashboard $ cd frontend && pnpm install && cd ..
+```
+
+#### Start the development servers
 
 ```bash
 # this will start the flask development server

--- a/files/ansible/install-deps.yaml
+++ b/files/ansible/install-deps.yaml
@@ -22,7 +22,6 @@
           - python3-pip
           - python3-flask
           - python3-flask-talisman
-          - python3-cachetools
           - python3-requests
           - "{{ node_pkg }}"
           - python3-mod_wsgi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Software Development",
 ]
 keywords = [
@@ -35,7 +38,6 @@ dependencies = [
     "Flask >= 2.0.0",
     "flask-cors >= 3.0.0",
     "flask-talisman >= 1.0.0",
-    "cachetools >= 4.0.0",
     "requests >= 2.20.0",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,53 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "packit-dashboard"
+# Using static version for now since the repo doesn't have version tags yet.
+# TODO: Switch to dynamic versioning with hatch-vcs when version tags are added.
+version = "0.1.0"
+authors = [
+    { name = "Red Hat", email = "hello@packit.dev" },
+]
+description = "Dashboard for Packit Service"
+readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
+requires-python = ">=3.9"
+classifiers = [
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Topic :: Software Development",
+]
+keywords = [
+    "packit",
+    "dashboard",
+]
+dependencies = [
+    "Flask >= 2.0.0",
+    "flask-cors >= 3.0.0",
+    "flask-talisman >= 1.0.0",
+    "cachetools >= 4.0.0",
+    "requests >= 2.20.0",
+]
+
+[project.urls]
+Homepage = "https://github.com/packit/dashboard"
+
+[project.optional-dependencies]
+testing = [
+    "pytest",
+    "pytest-cov",
+    "requre",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["packit_dashboard"]


### PR DESCRIPTION
Resolves #201 by adding proper dependency handling for local development using `pyproject.toml` (following the same pattern as the packit package).

🤖 Generated with [Claude Code](https://claude.com/claude-code)