### PR TITLE
Display error msg for failed Log Detective runs

### DIFF
--- a/frontend/src/apiDefinitions.ts
+++ b/frontend/src/apiDefinitions.ts
@@ -504,6 +504,7 @@ export interface LogDetectiveResultGroup {
   chroot: string;
   commit_sha: string;
   log_detective_response: LogDetectiveResponse | null;
+  error_msg: string | null;
   target_build: string | null;
   run_ids: number[];
   submitted_time: number | null;
@@ -559,6 +560,7 @@ export interface LogDetectiveResult {
   run_ids: number[];
   status: string;
   log_detective_response: LogDetectiveResponse | null;
+  error_msg: string | null;
   target_build: string | null;
   submitted_time: number | null;
   project_url: string;

--- a/frontend/src/components/logdetective/LogDetectiveResult.tsx
+++ b/frontend/src/components/logdetective/LogDetectiveResult.tsx
@@ -107,16 +107,32 @@ export const LogDetectiveResult = () => {
                   </DescriptionListGroup>
                 </DescriptionList>
               </CardBody>
-              {data.log_detective_response?.explanation ? (
+              {data.status === "complete" && data.log_detective_response ? (
+                <CardBody>
+                  <DescriptionList>
+                    {data.log_detective_response.explanation?.text ? (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Explanation</DescriptionListTerm>
+                        <DescriptionListDescription>
+                          <CodeBlock>
+                            <CodeBlockCode>
+                              {data.log_detective_response.explanation.text}
+                            </CodeBlockCode>
+                          </CodeBlock>
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    ) : null}
+                  </DescriptionList>
+                </CardBody>
+              ) : null}
+              {data.status === "error" && data.error_msg ? (
                 <CardBody>
                   <DescriptionList>
                     <DescriptionListGroup>
-                      <DescriptionListTerm>Explanation</DescriptionListTerm>
+                      <DescriptionListTerm>Error</DescriptionListTerm>
                       <DescriptionListDescription>
                         <CodeBlock>
-                          <CodeBlockCode>
-                            {data.log_detective_response.explanation.text}
-                          </CodeBlockCode>
+                          <CodeBlockCode>{data.error_msg}</CodeBlockCode>
                         </CodeBlock>
                       </DescriptionListDescription>
                     </DescriptionListGroup>


### PR DESCRIPTION
The error is displayed in the same way as the explanation:
<img width="1390" height="357" alt="image" src="https://github.com/user-attachments/assets/2ccc7fbe-9517-44fa-af3d-bfa3d6c51ee3" />

I also conditioned the display on `status`.

This should be fine to merge, even though https://github.com/packit/packit-service/pull/3151 is not yet in prod. I checked and display works fine even if error_msg field is not present, or null.

RELEASE NOTES BEGIN

Display error messages for failed Log Detective runs.

RELEASE NOTES END
