### PR TITLE
Link Koji build for Log Detective run

### DIFF
--- a/frontend/src/components/logdetective/LogDetectiveResult.tsx
+++ b/frontend/src/components/logdetective/LogDetectiveResult.tsx
@@ -105,6 +105,20 @@ export const LogDetectiveResult = () => {
                       <Timestamp stamp={data.submitted_time} verbose={true} />
                     </DescriptionListDescription>
                   </DescriptionListGroup>
+                  {data.target_build ? (
+                    <DescriptionListGroup>
+                      <DescriptionListTerm>Koji Build</DescriptionListTerm>
+                      <DescriptionListDescription>
+                        <a
+                          href={`https://koji.fedoraproject.org/koji/taskinfo?taskID=${data.target_build}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {data.target_build}
+                        </a>
+                      </DescriptionListDescription>
+                    </DescriptionListGroup>
+                  ) : null}
                 </DescriptionList>
               </CardBody>
               {data.log_detective_response?.explanation ? (


### PR DESCRIPTION
Related to: https://github.com/packit/dashboard/pull/537
<img width="1389" height="444" alt="image" src="https://github.com/user-attachments/assets/a3a5b85e-3b6d-45ad-8df4-79cb73661a1a" />


RELEASE NOTES BEGIN

Link related Koji scratch build in the Log Detective result overview.

RELEASE NOTES END
