### PR TITLE
Display solution for Log Detective runs

### DIFF
--- a/frontend/src/apiDefinitions.ts
+++ b/frontend/src/apiDefinitions.ts
@@ -546,8 +546,13 @@ export interface LogDetectiveExplanation {
   text: string;
 }
 
+export interface LogDetectiveSolution {
+  text: string;
+}
+
 export interface LogDetectiveResponse {
   explanation: LogDetectiveExplanation;
+  solution: LogDetectiveSolution | null;
   response_certainty: number;
 }
 

--- a/frontend/src/components/logdetective/LogDetectiveResult.tsx
+++ b/frontend/src/components/logdetective/LogDetectiveResult.tsx
@@ -136,6 +136,18 @@ export const LogDetectiveResult = () => {
                         </DescriptionListDescription>
                       </DescriptionListGroup>
                     ) : null}
+                    {data.log_detective_response.solution?.text ? (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>Solution</DescriptionListTerm>
+                        <DescriptionListDescription>
+                          <CodeBlock>
+                            <CodeBlockCode>
+                              {data.log_detective_response.solution.text}
+                            </CodeBlockCode>
+                          </CodeBlock>
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    ) : null}
                   </DescriptionList>
                 </CardBody>
               ) : null}


### PR DESCRIPTION
Solution feature is experimental and may produce misleading/annoying results, we need to be able to quickly opt-out of displaying it, which means adding some sort of flag to config.

It's not possible to add such a flag to the dashboard and would be complicated to do in packit-service, we will do it on log detective's side.

RELEASE NOTES BEGIN

Display solution in Log Detective result, if present and run is completed.

RELEASE NOTES END
