### PR TITLE
Show snippets in Log Detective runs

### DIFF
--- a/frontend/src/apiDefinitions.ts
+++ b/frontend/src/apiDefinitions.ts
@@ -550,9 +550,17 @@ export interface LogDetectiveSolution {
   text: string;
 }
 
+export interface LogDetectiveSnippet {
+  text: string;
+  line_number: number;
+  source_file: string;
+  snippet_analysis?: string;
+}
+
 export interface LogDetectiveResponse {
   explanation: LogDetectiveExplanation;
   solution: LogDetectiveSolution | null;
+  snippets: LogDetectiveSnippet[] | null;
   response_certainty: number;
 }
 

--- a/frontend/src/apiDefinitions.ts
+++ b/frontend/src/apiDefinitions.ts
@@ -542,7 +542,6 @@ export interface LogDetectiveGroup {
 
 // /api/log-detective/$id
 export interface LogDetectiveExplanation {
-  logprobs: unknown | null;
   text: string;
 }
 
@@ -559,9 +558,9 @@ export interface LogDetectiveSnippet {
 
 export interface LogDetectiveResponse {
   explanation: LogDetectiveExplanation;
+  no_issue_found: boolean;
   solution: LogDetectiveSolution | null;
   snippets: LogDetectiveSnippet[] | null;
-  response_certainty: number;
 }
 
 export interface LogDetectiveResult {

--- a/frontend/src/components/logdetective/LogDetectiveResult.tsx
+++ b/frontend/src/components/logdetective/LogDetectiveResult.tsx
@@ -11,17 +11,136 @@ import {
   DescriptionListDescription,
   DescriptionListGroup,
   DescriptionListTerm,
+  ExpandableSection,
   PageSection,
   Title,
 } from "@patternfly/react-core";
 
 import { useQuery } from "@tanstack/react-query";
+import type { CSSProperties } from "react";
+import type { LogDetectiveSnippet } from "../../apiDefinitions";
 import { logDetectiveResultQueryOptions } from "../../queries/logdetective/logDetectiveResultQuery";
 import { Route as LogDetectiveRoute } from "../../routes/jobs_/log-detective.$id";
 import { ErrorConnection } from "../errors/ErrorConnection";
 import { Preloader } from "../shared/Preloader";
 import { Timestamp } from "../shared/Timestamp";
 import { StatusLabel } from "../statusLabels/StatusLabel";
+
+// PF CodeBlock has very generous default padding; these overrides keep snippet rows compact.
+// The `as` cast is needed because PF CSS custom properties aren't in the CSSProperties type.
+const snippetBlockStyle = {
+  "--pf-v6-c-code-block__content--PaddingBlockStart": "4px",
+  "--pf-v6-c-code-block__content--PaddingBlockEnd": "4px",
+  "--pf-v6-c-code-block__content--PaddingInlineStart": "8px",
+  "--pf-v6-c-code-block__content--PaddingInlineEnd": "8px",
+  overflow: "hidden",
+} as CSSProperties;
+
+// color-mix blends the PF theme background with a green tint, so it adapts to both light and dark mode
+const analysisBlockStyle = {
+  ...snippetBlockStyle,
+  "--pf-v6-c-code-block--BackgroundColor":
+    "color-mix(in srgb, var(--pf-t--global--background--color--secondary--default) 85%, #a3d977)",
+} as CSSProperties;
+
+// SnippetRow renders as a direct child of the SnippetsList grid
+// so each element here becomes a grid item; should not be wrapped in a container div.
+const SnippetRow = ({ snippet }: { snippet: LogDetectiveSnippet }) => (
+  <>
+    <Content
+      style={{
+        minWidth: "5ch",
+        textAlign: "right" as const,
+        fontFamily: "var(--pf-t--global--font--family--mono)",
+        fontSize: "0.85em",
+      }}
+    >
+      {snippet.line_number}:
+    </Content>
+    <CodeBlock style={snippetBlockStyle}>
+      <CodeBlockCode
+        style={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {snippet.text}
+      </CodeBlockCode>
+    </CodeBlock>
+    {snippet.snippet_analysis ? (
+      <div
+        style={{
+          gridColumn: 2,
+          display: "grid",
+          gridTemplateColumns: "auto 1fr",
+          columnGap: "16px",
+          alignItems: "start",
+        }}
+      >
+        <Content
+          style={{
+            fontFamily: "var(--pf-t--global--font--family--mono)",
+            fontSize: "0.85em",
+          }}
+        >
+          Analysis:
+        </Content>
+        <CodeBlock style={analysisBlockStyle}>
+          <CodeBlockCode>{snippet.snippet_analysis}</CodeBlockCode>
+        </CodeBlock>
+      </div>
+    ) : null}
+  </>
+);
+
+const SnippetsList = ({
+  snippets,
+}: {
+  snippets: LogDetectiveSnippet[];
+}) => {
+  const grouped = Object.groupBy(snippets, (s) => s.source_file);
+  const sortedFiles = Object.keys(grouped).sort();
+
+  return (
+    <>
+      {sortedFiles.map((file) => (
+        <ExpandableSection
+          key={file}
+          toggleContent={
+            <span
+              style={{
+                color: "var(--pf-t--global--text--color--regular)",
+              }}
+            >
+              {file} ({grouped[file]!.length})
+            </span>
+          }
+          isIndented
+        >
+          {/* CSS grid aligns line numbers and code blocks into columns */}
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "auto 1fr",
+              columnGap: "16px",
+              rowGap: "8px",
+              alignItems: "start",
+              marginBlock: "8px",
+            }}
+          >
+            {grouped[file]!.map((snippet, index) => (
+              <SnippetRow
+                key={`${snippet.line_number}-${index}`}
+                snippet={snippet}
+              />
+            ))}
+          </div>
+        </ExpandableSection>
+      ))}
+    </>
+  );
+};
 
 export const LogDetectiveResult = () => {
   const { id } = LogDetectiveRoute.useParams();
@@ -145,6 +264,19 @@ export const LogDetectiveResult = () => {
                               {data.log_detective_response.solution.text}
                             </CodeBlockCode>
                           </CodeBlock>
+                        </DescriptionListDescription>
+                      </DescriptionListGroup>
+                    ) : null}
+                    {data.log_detective_response.snippets?.length ? (
+                      <DescriptionListGroup>
+                        <DescriptionListTerm>
+                          Snippets (
+                          {data.log_detective_response.snippets.length})
+                        </DescriptionListTerm>
+                        <DescriptionListDescription>
+                          <SnippetsList
+                            snippets={data.log_detective_response.snippets}
+                          />
                         </DescriptionListDescription>
                       </DescriptionListGroup>
                     ) : null}


### PR DESCRIPTION
Successful Log Detective run overview now shows also a list of snippets, grouped by file, in expandable sections.

I needed to do a couple of hacks to override coloring (to be visible in dark/light mode) for snippet analysis and to change the default padding of the text blocks. Some hacks are not that important, I just wanted some things to look a certain way.

Disclaimer: the snippets and analysis content in the screenshot are a mix of some actual Log Detective runs and some random stuff I added just for visual checking.

Default view:
<img width="885" height="793" alt="image" src="https://github.com/user-attachments/assets/6e69b5d0-b417-4506-8249-dc261fc66ec1" />

Expanded view:
<img width="839" height="791" alt="image" src="https://github.com/user-attachments/assets/eee86aa7-00a8-40e4-99ba-4f46e97e0bc5" />

Dark mode:
<img width="834" height="556" alt="image" src="https://github.com/user-attachments/assets/052a123e-8d91-4553-9f46-c0aada46ceae" />

RELEASE NOTES BEGIN

Show list of snippets grouped by file in the Log Detective run view.

RELEASE NOTES END
